### PR TITLE
#34: Optimize functional tests

### DIFF
--- a/tests/functional/acp_base.php
+++ b/tests/functional/acp_base.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ *
+ * Advertisement management. An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ads\tests\functional;
+
+/**
+* @group functional
+*/
+class acp_base extends \phpbb_functional_test_case
+{
+	/**
+	* {@inheritDoc}
+	*/
+	static protected function setup_extensions()
+	{
+		return array('phpbb/ads');
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->add_lang_ext('phpbb/ads', array(
+			'info_acp_phpbb_ads',
+			'acp',
+		));
+
+		$this->login();
+		$this->admin_login();
+	}
+}

--- a/tests/functional/acp_manage_test.php
+++ b/tests/functional/acp_manage_test.php
@@ -65,19 +65,13 @@ class acp_manage_test extends acp_base
 		$form_data = array(
 			'ad_priority'	=> 0,
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_PRIORITY_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_PRIORITY_INVALID'));
 
 		// Confirm error when submitting too high priority
 		$form_data = array(
 			'ad_priority'	=> 11,
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_PRIORITY_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_PRIORITY_INVALID'));
 
 		// Create ad
 		$form_data = array(
@@ -151,19 +145,13 @@ class acp_manage_test extends acp_base
 		$form_data = array(
 			'ad_priority'	=> 0,
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_PRIORITY_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_PRIORITY_INVALID'));
 
 		// Confirm error when submitting too high priority
 		$form_data = array(
 			'ad_priority'	=> 11,
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_PRIORITY_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_PRIORITY_INVALID'));
 
 		// Edit ad
 		$form_data = array(

--- a/tests/functional/acp_manage_test.php
+++ b/tests/functional/acp_manage_test.php
@@ -13,36 +13,12 @@ namespace phpbb\ads\tests\functional;
 /**
 * @group functional
 */
-class acp_test extends \phpbb_functional_test_case
+class acp_manage_test extends acp_base
 {
-	/**
-	* {@inheritDoc}
-	*/
-	static protected function setup_extensions()
-	{
-		return array('phpbb/ads');
-	}
-
-	/**
-	* {@inheritDoc}
-	*/
-	public function setUp()
-	{
-		parent::setUp();
-
-		$this->add_lang_ext('phpbb/ads', array(
-			'info_acp_phpbb_ads',
-			'acp',
-		));
-
-		$this->login();
-		$this->admin_login();
-	}
-
 	/**
 	* Test that Advertisement management ACP module appears
 	*/
-	public function test_acp_module()
+	public function test_acp_manage_module()
 	{
 		// Load Advertisement management ACP page
 		$crawler = $this->get_manage_page();
@@ -274,45 +250,6 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContains(strip_tags($this->lang('ACP_PHPBB_ADS_EDIT_LOG', 'Functional test name edited')), $crawler->text());
 	}
 
-	/**
-	* Test Advertisement management ACP settings
-	*/
-	public function test_acp_settings()
-	{
-		// Load Advertisement management ACP page
-		$crawler = $this->get_settings_page();
-
-		// Confirm page contains proper heading
-		$this->assertContainsLang('SETTINGS', $crawler->text());
-
-		// Confirm no group is selected yet
-		$this->assertCount(0, $crawler->filter('option[selected]'));
-
-		// Submit form
-		$form_data = array(
-			'adblocker_message'	=> 1,
-			'hide_groups'		=> array(5),
-		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertContainsLang('ACP_AD_SETTINGS_SAVED', $crawler->text());
-
-		// Load Advertisement management ACP page again
-		$crawler = $this->get_settings_page();
-
-		// Confirm Adblocker is enabled and admin group is selected
-		$this->assertEquals('1', $crawler->filter('input[name="adblocker_message"][checked]')->attr('value'));
-		$this->assertContainsLang('ADMINISTRATORS', $crawler->filter('option[selected]')->text());
-
-		// Reset hide groups
-		$crawler = $this->get_settings_page();
-		$form_data = array(
-			'hide_groups'	=> array(),
-		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		self::submit($form, $form_data);
-	}
-
 	static public function click($link)
 	{
 		return self::$client->click($link);
@@ -321,11 +258,6 @@ class acp_test extends \phpbb_functional_test_case
 	protected function get_manage_page()
 	{
 		return self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
-	}
-
-	protected function get_settings_page()
-	{
-		return self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
 	}
 
 	protected function submit_with_error($crawler, $form_data, $error_lang)

--- a/tests/functional/acp_settings_test.php
+++ b/tests/functional/acp_settings_test.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *
+ * Advertisement management. An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ads\tests\functional;
+
+/**
+* @group functional
+*/
+class acp_settings_test extends acp_base
+{
+	/**
+	* Test Advertisement management ACP settings
+	*/
+	public function test_acp_settings()
+	{
+		// Load Advertisement management ACP page
+		$crawler = $this->get_settings_page();
+
+		// Confirm page contains proper heading
+		$this->assertContainsLang('SETTINGS', $crawler->text());
+
+		// Confirm no group is selected yet
+		$this->assertCount(0, $crawler->filter('option[selected]'));
+
+		// Submit form
+		$form_data = array(
+			'adblocker_message'	=> 1,
+			'hide_groups'		=> array(5),
+		);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, $form_data);
+		$this->assertContainsLang('ACP_AD_SETTINGS_SAVED', $crawler->text());
+
+		// Load Advertisement management ACP page again
+		$crawler = $this->get_settings_page();
+
+		// Confirm Adblocker is enabled and admin group is selected
+		$this->assertEquals('1', $crawler->filter('input[name="adblocker_message"][checked]')->attr('value'));
+		$this->assertContainsLang('ADMINISTRATORS', $crawler->filter('option[selected]')->text());
+
+		// Reset hide groups
+		$crawler = $this->get_settings_page();
+		$form_data = array(
+			'hide_groups'	=> array(),
+		);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		self::submit($form, $form_data);
+	}
+
+	protected function get_settings_page()
+	{
+		return self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+	}
+}

--- a/tests/functional/acp_test.php
+++ b/tests/functional/acp_test.php
@@ -45,7 +45,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_module()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Assert Advertisement management module appears in sidebar
 		$this->assertContainsLang('ACP_PHPBB_ADS_TITLE', $crawler->filter('.menu-block')->text());
@@ -63,7 +63,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_add()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Jump to the add page
 		$form = $crawler->selectButton($this->lang('ACP_ADS_ADD'))->form();
@@ -71,28 +71,19 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_ADS_ADD', $crawler->filter('#main h1')->text());
 
 		// Confirm error when submitting without required field data
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_NAME_REQUIRED', $crawler->text());
+		$this->submit_with_error($crawler, array(), $this->lang('AD_NAME_REQUIRED'));
 
 		// Confirm error when submitting too long ad name
 		$form_data = array(
 			'ad_name'		=> str_repeat('a', 256),
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContains($this->lang('AD_NAME_TOO_LONG', 255), $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_NAME_TOO_LONG', 255));
 
 		// Confirm error when submitting old end date
 		$form_data = array(
 			'ad_end_date'	=> '2000-01-01',
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_END_DATE_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_END_DATE_INVALID'));
 
 		// Confirm error when submitting too low priority
 		$form_data = array(
@@ -135,7 +126,7 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_AD_ADD_SUCCESS', $crawler->text());
 
 		// Confirm new ad appears in the list, is enabled and end date is displayed correctly
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 		$this->assertContains('Functional test name', $crawler->text());
 		$this->assertContainsLang('ENABLED', $crawler->text());
 		$this->assertContains('2035-01-01', $crawler->text());
@@ -151,7 +142,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_edit()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Hit edit button
 		$edit_link = $crawler->filter('[title="' . $this->lang('EDIT') . '"]')->parents()->first()->link();
@@ -166,28 +157,19 @@ class acp_test extends \phpbb_functional_test_case
 			'ad_enabled'	=> false,
 			'ad_end_date'	=> '',
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_NAME_REQUIRED', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_NAME_REQUIRED'));
 
 		// Confirm error when submitting too long ad name
 		$form_data = array(
 			'ad_name'		=> str_repeat('a', 256),
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContains($this->lang('AD_NAME_TOO_LONG', 255), $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_NAME_TOO_LONG', 255));
 
 		// Confirm error when submitting old end date
 		$form_data = array(
 			'ad_end_date'	=> '2000-01-01',
 		);
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-		$crawler = self::submit($form, $form_data);
-		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
-		$this->assertContainsLang('AD_END_DATE_INVALID', $crawler->text());
+		$this->submit_with_error($crawler, $form_data, $this->lang('AD_END_DATE_INVALID'));
 
 		// Confirm error when submitting too low priority
 		$form_data = array(
@@ -230,7 +212,7 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_AD_EDIT_SUCCESS', $crawler->text());
 
 		// Confirm new ad appears in the list, is disabled and end date is present and updated
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 		$this->assertContains('Functional test name edited', $crawler->text());
 		$this->assertContainsLang('DISABLED', $crawler->text());
 		$this->assertContains('2035-01-02', $crawler->text());
@@ -246,7 +228,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_enable()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Hit Disabled button
 		$enable_link = $crawler->selectLink($this->lang('DISABLED'))->link();
@@ -254,7 +236,7 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_AD_ENABLE_SUCCESS', $crawler->text());
 
 		// Load Advertisement management ACP page again
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Hit Enabled button
 		$disable_link = $crawler->selectLink($this->lang('ENABLED'))->link();
@@ -268,7 +250,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_delete()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 
 		// Hit delete button
 		$delete_link = $crawler->filter('[title="' . $this->lang('DELETE') . '"]')->parents()->first()->link();
@@ -284,7 +266,7 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_AD_DELETE_SUCCESS', $crawler->text());
 
 		// Confirm ad list is empty
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+		$crawler = $this->get_manage_page();
 		$this->assertContainsLang('ACP_ADS_EMPTY', $crawler->filter('#main')->text());
 
 		// Confirm the log entry has been added correctly
@@ -298,7 +280,7 @@ class acp_test extends \phpbb_functional_test_case
 	public function test_acp_settings()
 	{
 		// Load Advertisement management ACP page
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+		$crawler = $this->get_settings_page();
 
 		// Confirm page contains proper heading
 		$this->assertContainsLang('SETTINGS', $crawler->text());
@@ -316,14 +298,14 @@ class acp_test extends \phpbb_functional_test_case
 		$this->assertContainsLang('ACP_AD_SETTINGS_SAVED', $crawler->text());
 
 		// Load Advertisement management ACP page again
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+		$crawler = $this->get_settings_page();
 
 		// Confirm Adblocker is enabled and admin group is selected
 		$this->assertEquals('1', $crawler->filter('input[name="adblocker_message"][checked]')->attr('value'));
 		$this->assertContainsLang('ADMINISTRATORS', $crawler->filter('option[selected]')->text());
 
 		// Reset hide groups
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+		$crawler = $this->get_settings_page();
 		$form_data = array(
 			'hide_groups'	=> array(),
 		);
@@ -334,5 +316,23 @@ class acp_test extends \phpbb_functional_test_case
 	static public function click($link)
 	{
 		return self::$client->click($link);
+	}
+
+	protected function get_manage_page()
+	{
+		return self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
+	}
+
+	protected function get_settings_page()
+	{
+		return self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+	}
+
+	protected function submit_with_error($crawler, $form_data, $error_lang)
+	{
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, $form_data);
+		$this->assertGreaterThan(0, $crawler->filter('.errorbox')->count());
+		$this->assertContains($error_lang, $crawler->text());
 	}
 }

--- a/tests/functional/adblocker_test.php
+++ b/tests/functional/adblocker_test.php
@@ -15,11 +15,19 @@ namespace phpbb\ads\tests\functional;
 */
 class adblocker_test extends functional_base
 {
-	/*
-	* @depends test_acp_settings
-	*/
 	public function test_adblocker_code_is_present()
 	{
+		// Enable ad blocker message
+		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=settings&sid={$this->sid}");
+		$form_data = array(
+			'adblocker_message'	=> 1,
+			'hide_groups'		=> array(),
+		);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, $form_data);
+		$this->assertContainsLang('ACP_AD_SETTINGS_SAVED', $crawler->text());
+
+		// Confirm ad blocker code is present
 		$crawler = self::request('GET', 'index.php');
 		$this->assertEquals(1, $crawler->filter('#phpbb-ads-ab')->count());
 	}

--- a/tests/functional/end_date_test.php
+++ b/tests/functional/end_date_test.php
@@ -43,24 +43,20 @@ class end_date_test extends functional_base
 
 		// Confirm above header ad is present
 		$this->assertContains($ad_code, $crawler->html());
-
-		return $ad_code;
 	}
 
-	/**
-	 * @depends test_future_end_date_displays
-	 */
-	public function test_past_end_date_is_not_displayed($ad_code)
+	public function test_past_end_date_is_not_displayed()
 	{
+		$ad_code = $this->create_ad('below_header', '2034-01-01');
+
 		// Change the ads end date to a time long ago
 		$sql = 'UPDATE phpbb_ads
-			SET ad_end_date = ' . strtotime('2000-01-01') . '
-			WHERE ad_end_date = ' . strtotime('2035-01-01');
+			SET ad_end_date = ' . strtotime('2000-01-01');
 		$this->db->sql_query($sql);
 
 		$crawler = self::request('GET', 'index.php');
 
-		// Confirm above header ad is present
+		// Confirm below header ad is not present
 		$this->assertNotContains($ad_code, $crawler->html());
 	}
 }

--- a/tests/functional/end_date_test.php
+++ b/tests/functional/end_date_test.php
@@ -22,14 +22,7 @@ class end_date_test extends functional_base
 	{
 		parent::setUp();
 
-		// Disable all existent ads
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
-		while (count($crawler->selectLink($this->lang('ENABLED'))))
-		{
-			$disable_link = $crawler->selectLink($this->lang('ENABLED'))->link();
-			self::$client->click($disable_link);
-			$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
-		}
+		$this->disable_all_ads();
 	}
 
 	public function test_no_end_date_displays()

--- a/tests/functional/end_date_test.php
+++ b/tests/functional/end_date_test.php
@@ -47,15 +47,13 @@ class end_date_test extends functional_base
 		return $ad_code;
 	}
 
-	/**
-	 * @depends test_future_end_date_displays
-	 */
-	public function test_past_end_date_is_not_displayed($ad_code)
+	public function test_past_end_date_is_not_displayed()
 	{
+		$ad_code = $this->create_ad('below_header');
+
 		// Change the ads end date to a time long ago
 		$sql = 'UPDATE phpbb_ads
-			SET ad_end_date = ' . strtotime('2000-01-01') . '
-			WHERE ad_end_date = ' . strtotime('2035-01-01');
+			SET ad_end_date = ' . strtotime('2000-01-01');
 		$this->db->sql_query($sql);
 
 		$crawler = self::request('GET', 'index.php');

--- a/tests/functional/end_date_test.php
+++ b/tests/functional/end_date_test.php
@@ -43,15 +43,19 @@ class end_date_test extends functional_base
 
 		// Confirm above header ad is present
 		$this->assertContains($ad_code, $crawler->html());
+
+		return $ad_code;
 	}
 
-	public function test_past_end_date_is_not_displayed()
+	/**
+	 * @depends test_future_end_date_displays
+	 */
+	public function test_past_end_date_is_not_displayed($ad_code)
 	{
-		$ad_code = $this->create_ad('below_header', '2034-01-01');
-
 		// Change the ads end date to a time long ago
 		$sql = 'UPDATE phpbb_ads
-			SET ad_end_date = ' . strtotime('2000-01-01');
+			SET ad_end_date = ' . strtotime('2000-01-01') . '
+			WHERE ad_end_date = ' . strtotime('2035-01-01');
 		$this->db->sql_query($sql);
 
 		$crawler = self::request('GET', 'index.php');

--- a/tests/functional/functional_base.php
+++ b/tests/functional/functional_base.php
@@ -66,4 +66,11 @@ class functional_base extends \phpbb_functional_test_case
 
 		return $form_data['ad_code'];
 	}
+
+	protected function disable_all_ads()
+	{
+		$sql = 'UPDATE phpbb_ads
+			SET ad_enabled = 0';
+		$this->db->sql_query($sql);
+	}
 }

--- a/tests/functional/hide_group_test.php
+++ b/tests/functional/hide_group_test.php
@@ -22,15 +22,7 @@ class hide_group_test extends functional_base
 	{
 		parent::setUp();
 
-		// Disable all existent ads
-		$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
-		while (count($crawler->selectLink($this->lang('ENABLED'))))
-		{
-			$disable_link = $crawler->selectLink($this->lang('ENABLED'))->link();
-			self::$client->click($disable_link);
-			$crawler = self::request('GET', "adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage&sid={$this->sid}");
-		}
-
+		$this->disable_all_ads();
 		$this->reset_groups();
 	}
 

--- a/tests/functional/hide_group_test.php
+++ b/tests/functional/hide_group_test.php
@@ -26,6 +26,11 @@ class hide_group_test extends functional_base
 		$this->reset_groups();
 	}
 
+	public function tearDown()
+	{
+		$this->reset_groups();
+	}
+
 	public function test_ad_displays_without_hide_group()
 	{
 		$ad_code = $this->create_ad('above_header');
@@ -54,8 +59,6 @@ class hide_group_test extends functional_base
 
 		// Confirm above header ad is not present
 		$this->assertNotContains($ad_code, $crawler->html());
-
-		$this->reset_groups();
 	}
 
 	protected function reset_groups()


### PR DESCRIPTION
Resolves #34 

Checklist: 
- [x] Add disable_all_ads() to functional_base, but use direct SQL query instead of crawler in loop.
- [x] Remove dependency from test_adblocker_code_is_present, because it depends on test of different class
- [x] Rationalize use of reset_groups() in hide_group_test - it needs to be called after every test, so use tearDown()
- [x] Split acp_test, because it is too big
- [x] Refactor acp_test (introduce get_manage_page(), get_settings_page() and submit_with_error($error_lang) (maybe we won't need to split the class after that)