### PR TITLE
Reorganize template events

### DIFF
--- a/styles/all/template/event/memberlist_view_content_append.html
+++ b/styles/all/template/event/memberlist_view_content_append.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_PROFILE, AD_AFTER_PROFILE_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/memberlist_view_content_prepend.html
+++ b/styles/all/template/event/memberlist_view_content_prepend.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_BEFORE_PROFILE, AD_BEFORE_PROFILE_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/overall_footer_after.html
+++ b/styles/all/template/event/overall_footer_after.html
@@ -1,15 +1,7 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_BELOW_FOOTER, AD_BELOW_FOOTER_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}
 
-{% if S_INCREMENT_VIEWS %}
-	<script>
-		(function($) {
-			'use strict';
-
-			$(window).on('load', function() {
-				$.get('{{ UA_PHPBB_ADS_VIEWS }}');
-			});
-		})(jQuery);
-	</script>
-{% endif %}
+{% include '@phpbb_ads/includes/ad_views.html' %}

--- a/styles/all/template/event/overall_footer_page_body_after.html
+++ b/styles/all/template/event/overall_footer_page_body_after.html
@@ -1,4 +1,6 @@
+{# begin ad location #}
 {# clear: both; is introduced because of jumpbox in user profile which is floating right #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0; clear: both;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_ABOVE_FOOTER, AD_ABOVE_FOOTER_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/overall_header_body_before.html
+++ b/styles/all/template/event/overall_header_body_before.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin-bottom: 10px;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_ABOVE_HEADER, AD_ABOVE_HEADER_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/overall_header_content_before.html
+++ b/styles/all/template/event/overall_header_content_before.html
@@ -1,32 +1,3 @@
 {% INCLUDECSS '@phpbb_ads/phpbbads.css' %}
-{% if S_PHPBB_ADS_ENABLE_CLICKS %}
-	<script>
-		var u_phpbb_ads_click = '{{ UA_PHPBB_ADS_CLICK }}';
-	</script>
-	{% INCLUDEJS '@phpbb_ads/js/clicks.js' %}
-{% endif %}
-
-{% if S_DISPLAY_ADBLOCKER %}
-<div id="phpbb-ads-ab" class="rules" style="display: none;">
-	<div class="inner">
-		<strong>{{ lang('ADBLOCKER_TITLE') ~ lang('COLON') }}</strong> {{ lang('ADBLOCKER_MESSAGE') }}
-	</div>
-</div>
-
-<script>
-	'use strict';
-
-	// Test presence of AdBlock and show message if present
-	// Credit: https://christianheilmann.com/2015/12/25/detecting-adblock-without-an-extra-http-overhead/
-	var test = document.createElement('div');
-	test.innerHTML = '&nbsp;';
-	test.className = 'adsbox';
-	document.body.appendChild(test);
-	window.setTimeout(function() {
-		if (test.offsetHeight === 0) {
-			document.getElementById('phpbb-ads-ab').removeAttribute('style');
-		}
-		test.remove();
-	}, 100);
-</script>
-{% endif %}
+{% include '@phpbb_ads/includes/ad_clicks.html' %}
+{% include '@phpbb_ads/includes/ad_blocker.html' %}

--- a/styles/all/template/event/overall_header_navbar_before.html
+++ b/styles/all/template/event/overall_header_navbar_before.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_BELOW_HEADER, AD_BELOW_HEADER_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/viewtopic_body_poll_after.html
+++ b/styles/all/template/event/viewtopic_body_poll_after.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_BEFORE_POSTS, AD_BEFORE_POSTS_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/event/viewtopic_body_postrow_post_after.html
+++ b/styles/all/template/event/viewtopic_body_postrow_post_after.html
@@ -1,3 +1,4 @@
+{# begin ad location #}
 {% if postrow.S_FIRST_ROW %}
 	{% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 	{% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_FIRST_POST, AD_AFTER_FIRST_POST_ID %}	{% set PHPBB_ADS_ID = AD_AFTER_FIRST_POST_ID %}
@@ -9,3 +10,4 @@
 	{% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_NOT_FIRST_POST, AD_AFTER_NOT_FIRST_POST_ID %}
 	{% include '@phpbb_ads/phpbb_ads_default.html' %}
 {% endif %}
+{# end ad location #}

--- a/styles/all/template/event/viewtopic_body_topic_actions_before.html
+++ b/styles/all/template/event/viewtopic_body_topic_actions_before.html
@@ -1,3 +1,5 @@
+{# begin ad location #}
 {% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
 {% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_POSTS, AD_AFTER_POSTS_ID %}
 {% include '@phpbb_ads/phpbb_ads_default.html' %}
+{# end ad location #}

--- a/styles/all/template/includes/ad_blocker.html
+++ b/styles/all/template/includes/ad_blocker.html
@@ -1,0 +1,24 @@
+{% if S_DISPLAY_ADBLOCKER %}
+	<div id="phpbb-ads-ab" class="rules" style="display: none;">
+		<div class="inner">
+			<strong>{{ lang('ADBLOCKER_TITLE') ~ lang('COLON') }}</strong> {{ lang('ADBLOCKER_MESSAGE') }}
+		</div>
+	</div>
+
+	<script>
+		'use strict';
+
+		// Test presence of AdBlock and show message if present
+		// Credit: https://christianheilmann.com/2015/12/25/detecting-adblock-without-an-extra-http-overhead/
+		var test = document.createElement('div');
+		test.innerHTML = '&nbsp;';
+		test.className = 'adsbox';
+		document.body.appendChild(test);
+		window.setTimeout(function() {
+			if (test.offsetHeight === 0) {
+				document.getElementById('phpbb-ads-ab').removeAttribute('style');
+			}
+			test.remove();
+		}, 100);
+	</script>
+{% endif %}

--- a/styles/all/template/includes/ad_clicks.html
+++ b/styles/all/template/includes/ad_clicks.html
@@ -1,0 +1,6 @@
+{% if S_PHPBB_ADS_ENABLE_CLICKS %}
+	<script>
+		var u_phpbb_ads_click = '{{ UA_PHPBB_ADS_CLICK }}';
+	</script>
+	{% INCLUDEJS '@phpbb_ads/js/clicks.js' %}
+{% endif %}

--- a/styles/all/template/includes/ad_views.html
+++ b/styles/all/template/includes/ad_views.html
@@ -1,0 +1,11 @@
+{% if S_INCREMENT_VIEWS %}
+	<script>
+		(function($) {
+			'use strict';
+
+			$(window).on('load', function() {
+				$.get('{{ UA_PHPBB_ADS_VIEWS }}');
+			});
+		})(jQuery);
+	</script>
+{% endif %}


### PR DESCRIPTION
@senky 

In this PR I am attemtping to re-organize our template event files.

It's a little confusing sometimes where to find code in them.

So with this PR I am moving all functional template code (like JS and stuff) into their own separate html files. This way, most of the template events will simply contain ad codes. And functional code can be found in the includes folder.