### PR TITLE
Address validation issues

### DIFF
--- a/ad/manager.php
+++ b/ad/manager.php
@@ -373,7 +373,6 @@ class manager
 			case 'sqlite3':
 				return '(0.5 - RANDOM() / CAST(-9223372036854775808 AS REAL) / 2)';
 
-			// All other cases
 			default:
 				return 'RAND()';
 		}

--- a/ad/manager.php
+++ b/ad/manager.php
@@ -373,12 +373,7 @@ class manager
 			case 'sqlite3':
 				return '(0.5 - RANDOM() / CAST(-9223372036854775808 AS REAL) / 2)';
 
-			/* All other cases should use the default
-			case 'mssql':
-			case 'mssql_odbc':
-			case 'mssqlnative':
-			case 'mysql':
-			case 'mysqli':*/
+			// All other cases
 			default:
 				return 'RAND()';
 		}

--- a/adm/style/event/acp_overall_footer_after.html
+++ b/adm/style/event/acp_overall_footer_after.html
@@ -36,7 +36,7 @@
 			minDate: 0,
 			timepicker: false
 		});
-		$.datetimepicker.setLocale('{{ S_USER_LANG|e('js') }}');
+		$.datetimepicker.setLocale('{{ S_USER_LANG }}');
 
 		$('#upload_banner').click(function(e) {
 			e.preventDefault();

--- a/adm/style/event/acp_overall_footer_after.html
+++ b/adm/style/event/acp_overall_footer_after.html
@@ -36,7 +36,7 @@
 			minDate: 0,
 			timepicker: false
 		});
-		$.datetimepicker.setLocale('{{ S_USER_LANG }}');
+		$.datetimepicker.setLocale('{{ S_USER_LANG|e('js') }}');
 
 		$('#upload_banner').click(function(e) {
 			e.preventDefault();
@@ -70,7 +70,7 @@
 				});
 			}
 			else {
-				phpbb.alert('{{ lang('INFORMATION') }}', '{{ lang('NO_FILE_SELECTED') }}');
+				phpbb.alert('{{ lang('INFORMATION')|e('js') }}', '{{ lang('NO_FILE_SELECTED')|e('js') }}');
 			}
 		});
 	});

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -186,7 +186,7 @@ class admin_controller
 		$upload_banner = $this->request->is_set_post('upload_banner');
 		$analyse_ad_code = $this->request->is_set_post('analyse_ad_code');
 
-		add_form_key('phpbb/ads/add');
+		$this->input->add_form_key('phpbb/ads/add');
 		if ($preview || $submit || $upload_banner || $analyse_ad_code)
 		{
 			$data = $this->input->get_form_data('phpbb/ads/add');
@@ -245,7 +245,7 @@ class admin_controller
 		$upload_banner = $this->request->is_set_post('upload_banner');
 		$analyse_ad_code = $this->request->is_set_post('analyse_ad_code');
 
-		add_form_key('phpbb/ads/edit/' . $ad_id);
+		$this->input->add_form_key('phpbb/ads/edit/' . $ad_id);
 		if ($preview || $submit || $upload_banner || $analyse_ad_code)
 		{
 			$data = $this->input->get_form_data('phpbb/ads/edit/' . $ad_id);

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -117,11 +117,10 @@ class admin_controller
 	{
 		$this->setup();
 
-		add_form_key('phpbb/ads/settings');
 		if ($this->request->is_set_post('submit'))
 		{
 			// Validate form key
-			if (check_form_key('phpbb/ads/settings'))
+			if (check_form_key('phpbb_ads'))
 			{
 				$this->config->set('phpbb_ads_adblocker_message', $this->request->variable('adblocker_message', 0));
 				$this->config->set('phpbb_ads_enable_views', $this->request->variable('enable_views', 0));
@@ -186,10 +185,9 @@ class admin_controller
 		$upload_banner = $this->request->is_set_post('upload_banner');
 		$analyse_ad_code = $this->request->is_set_post('analyse_ad_code');
 
-		$this->input->add_form_key('phpbb/ads/add');
 		if ($preview || $submit || $upload_banner || $analyse_ad_code)
 		{
-			$data = $this->input->get_form_data('phpbb/ads/add');
+			$data = $this->input->get_form_data();
 
 			if ($preview)
 			{
@@ -245,10 +243,9 @@ class admin_controller
 		$upload_banner = $this->request->is_set_post('upload_banner');
 		$analyse_ad_code = $this->request->is_set_post('analyse_ad_code');
 
-		$this->input->add_form_key('phpbb/ads/edit/' . $ad_id);
 		if ($preview || $submit || $upload_banner || $analyse_ad_code)
 		{
-			$data = $this->input->get_form_data('phpbb/ads/edit/' . $ad_id);
+			$data = $this->input->get_form_data();
 
 			if ($preview)
 			{

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -48,6 +48,8 @@ class admin_input
 		$this->language = $language;
 		$this->request = $request;
 		$this->banner = $banner;
+
+		add_form_key('phpbb_ads');
 	}
 
 	/**
@@ -71,23 +73,11 @@ class admin_input
 	}
 
 	/**
-	 * Add CSRF form key.
-	 *
-	 * @param	string	$form_name	The form name.
-	 * @return	void
-	 */
-	public function add_form_key($form_name)
-	{
-		add_form_key($form_name);
-	}
-
-	/**
 	 * Get admin form data.
 	 *
-	 * @param	string	$form_name	The form name.
 	 * @return	array	Form data
 	 */
-	public function get_form_data($form_name)
+	public function get_form_data()
 	{
 		$data = array(
 			'ad_name'         => $this->request->variable('ad_name', '', true),
@@ -103,7 +93,7 @@ class admin_input
 		);
 
 		// Validate form key
-		if (!check_form_key($form_name))
+		if (!check_form_key('phpbb_ads'))
 		{
 			$this->errors[] = $this->language->lang('FORM_INVALID');
 		}

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -71,6 +71,17 @@ class admin_input
 	}
 
 	/**
+	 * Add CSRF form key.
+	 *
+	 * @param	string	$form_name	The form name.
+	 * @return	void
+	 */
+	public function add_form_key($form_name)
+	{
+		add_form_key($form_name);
+	}
+
+	/**
 	 * Get admin form data.
 	 *
 	 * @param	string	$form_name	The form name.

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -122,7 +122,7 @@ class main_listener implements EventSubscriberInterface
 					'S_INCREMENT_VIEWS'		=> true,
 					// Obfuscate URL to prevent crawlers increasing view counters.
 					// Uses http://www.jsfuck.com/ to make 'a' really complicated, yet executable.
-					'U_PHPBB_ADS_VIEWS'	=> str_replace('adsview', "' + (![]+[])[+!+[]] + 'dsview", $this->controller_helper->route('phpbb_ads_view', array('data' => implode('-', $ad_ids)))),
+					'U_PHPBB_ADS_VIEWS'	=> $this->controller_helper->route('phpbb_ads_view', array('data' => implode('-', $ad_ids))),
 				));
 			}
 		}

--- a/event/main_listener.php
+++ b/event/main_listener.php
@@ -122,7 +122,7 @@ class main_listener implements EventSubscriberInterface
 					'S_INCREMENT_VIEWS'		=> true,
 					// Obfuscate URL to prevent crawlers increasing view counters.
 					// Uses http://www.jsfuck.com/ to make 'a' really complicated, yet executable.
-					'UA_PHPBB_ADS_VIEWS'	=> str_replace('adsview', "' + (![]+[])[+!+[]] + 'dsview", $this->controller_helper->route('phpbb_ads_view', array('data' => implode('-', $ad_ids)))),
+					'U_PHPBB_ADS_VIEWS'	=> str_replace('adsview', "' + (![]+[])[+!+[]] + 'dsview", $this->controller_helper->route('phpbb_ads_view', array('data' => implode('-', $ad_ids)))),
 				));
 			}
 		}
@@ -134,7 +134,7 @@ class main_listener implements EventSubscriberInterface
 		if ($this->config['phpbb_ads_enable_clicks'])
 		{
 			$this->template->assign_vars(array(
-				'UA_PHPBB_ADS_CLICK'		=> $this->controller_helper->route('phpbb_ads_click', array('data' => 0)),
+				'U_PHPBB_ADS_CLICK'		=> $this->controller_helper->route('phpbb_ads_click', array('data' => 0)),
 				'S_PHPBB_ADS_ENABLE_CLICKS'	=> true,
 			));
 		}

--- a/styles/all/template/event/viewtopic_body_postrow_post_after.html
+++ b/styles/all/template/event/viewtopic_body_postrow_post_after.html
@@ -1,7 +1,7 @@
 {# begin ad location #}
 {% if postrow.S_FIRST_ROW %}
 	{% set PHPBB_ADS_STYLE = 'margin: 10px 0;' %}
-	{% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_FIRST_POST, AD_AFTER_FIRST_POST_ID %}	{% set PHPBB_ADS_ID = AD_AFTER_FIRST_POST_ID %}
+	{% set PHPBB_ADS_CODE, PHPBB_ADS_ID = AD_AFTER_FIRST_POST, AD_AFTER_FIRST_POST_ID %}
 	{% include '@phpbb_ads/phpbb_ads_default.html' %}
 {% endif %}
 

--- a/styles/all/template/includes/ad_clicks.html
+++ b/styles/all/template/includes/ad_clicks.html
@@ -1,6 +1,6 @@
 {% if S_PHPBB_ADS_ENABLE_CLICKS %}
 	<script>
-		var u_phpbb_ads_click = '{{ UA_PHPBB_ADS_CLICK }}';
+		var u_phpbb_ads_click = '{{ U_PHPBB_ADS_CLICK|e('js') }}';
 	</script>
 	{% INCLUDEJS '@phpbb_ads/js/clicks.js' %}
 {% endif %}

--- a/styles/all/template/includes/ad_views.html
+++ b/styles/all/template/includes/ad_views.html
@@ -4,7 +4,7 @@
 			'use strict';
 
 			$(window).on('load', function() {
-				$.get('{{ UA_PHPBB_ADS_VIEWS }}');
+				$.get('{{ U_PHPBB_ADS_VIEWS|e('js') }}');
 			});
 		})(jQuery);
 	</script>

--- a/styles/all/template/includes/phpbb_ads_pop_up.html
+++ b/styles/all/template/includes/phpbb_ads_pop_up.html
@@ -3,7 +3,7 @@
 		'use strict';
 
 		$(window).on('load', function() {
-			document.cookie = '{{ POP_UP_COOKIE_NAME|e('js') }}=true; expires={{ POP_UP_COOKIE_EXPIRES|e('js') }}; path={{ POP_UP_COOKIE_PATH|e('js') }}';
+			document.cookie = '{{ POP_UP_COOKIE_NAME }}=true; expires={{ POP_UP_COOKIE_EXPIRES }}; path={{ POP_UP_COOKIE_PATH }}';
 			phpbb.alert('{{ lang('ADVERTISEMENT')|e('js')|upper }}', `{% include '@phpbb_ads/phpbb_ads_default.html' %}`);
 		});
 	})(jQuery, window, document, phpbb);

--- a/styles/all/template/includes/phpbb_ads_pop_up.html
+++ b/styles/all/template/includes/phpbb_ads_pop_up.html
@@ -3,8 +3,8 @@
 		'use strict';
 
 		$(window).on('load', function() {
-			document.cookie = '{{ POP_UP_COOKIE_NAME }}=true; expires={{ POP_UP_COOKIE_EXPIRES }}; path={{ POP_UP_COOKIE_PATH }}';
-			phpbb.alert('{{ lang('ADVERTISEMENT')|upper }}', `{% include '@phpbb_ads/phpbb_ads_default.html' %}`);
+			document.cookie = '{{ POP_UP_COOKIE_NAME|e('js') }}=true; expires={{ POP_UP_COOKIE_EXPIRES|e('js') }}; path={{ POP_UP_COOKIE_PATH|e('js') }}';
+			phpbb.alert('{{ lang('ADVERTISEMENT')|e('js')|upper }}', `{% include '@phpbb_ads/phpbb_ads_default.html' %}`);
 		});
 	})(jQuery, window, document, phpbb);
 </script>

--- a/styles/all/template/phpbb_ads_default.html
+++ b/styles/all/template/phpbb_ads_default.html
@@ -1,5 +1,5 @@
 {% if PHPBB_ADS_CODE %}
-	<div class="phpbb-ads-center" style="{{ PHPBB_ADS_STYLE }}" data-ad-id="{{ PHPBB_ADS_ID }}">
+	<div class="phpbb-ads-center" style="{{ PHPBB_ADS_STYLE }}" data-ad-id="{{ PHPBB_ADS_ID|e('html_attr') }}">
 		{{ PHPBB_ADS_CODE }}
 	</div>
 {% endif %}

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -443,7 +443,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/add')
 			->willReturn(array(
 				'ad_code'		=> '<!-- AD CODE SAMPLE -->',
 				'ad_locations'	=> array(),
@@ -504,7 +503,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/add')
 			->willReturn(array(
 				'ad_code'		=> 'Ad Code #1',
 				'ad_locations'	=> array(),
@@ -566,7 +564,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/add')
 			->willReturn(array(
 				'ad_code'		=> 'Ad Code #1',
 				'ad_locations'	=> array(),
@@ -642,7 +639,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/add')
 			->willReturn(array(
 				'ad_name'		=> 'Ad Name #1',
 				'ad_code'		=> 'Ad Code #1',
@@ -860,7 +856,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/edit/1')
 			->willReturn(array(
 				'ad_code'		=> 'Ad Code #1',
 				'ad_locations'	=> array(),
@@ -958,7 +953,6 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects($this->once())
 			->method('get_form_data')
-			->with('phpbb/ads/edit/1')
 			->willReturn(array(
 				'ad_name'		=> 'Ad Name #1',
 				'ad_code'		=> 'Ad Code #1',

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -1197,11 +1197,3 @@ function confirm_box()
 {
 	return \phpbb\ads\controller\admin_controller_test::$confirm;
 }
-
-/**
- * Mock add_form_key()
- * Note: use the same namespace as the admin_controller
- */
-function add_form_key()
-{
-}

--- a/tests/controller/admin_input_test.php
+++ b/tests/controller/admin_input_test.php
@@ -242,3 +242,11 @@ function check_form_key()
 {
 	return \phpbb\ads\controller\admin_input_test::$valid_form;
 }
+
+/**
+ * Mock add_form_key()
+ * Note: use the same namespace as the admin_input
+ */
+function add_form_key()
+{
+}

--- a/tests/event/setup_ads_test.php
+++ b/tests/event/setup_ads_test.php
@@ -123,7 +123,7 @@ class setup_ads_test extends main_listener_base
 				->method('assign_vars')
 				->with(array(
 					'S_INCREMENT_VIEWS'		=> true,
-					'U_PHPBB_ADS_VIEWS'	=> "app.php/' + (![]+[])[+!+[]] + 'dsview/1",
+					'U_PHPBB_ADS_VIEWS'	=> "app.php/adsview/1",
 				));
 		}
 

--- a/tests/event/setup_ads_test.php
+++ b/tests/event/setup_ads_test.php
@@ -123,7 +123,7 @@ class setup_ads_test extends main_listener_base
 				->method('assign_vars')
 				->with(array(
 					'S_INCREMENT_VIEWS'		=> true,
-					'UA_PHPBB_ADS_VIEWS'	=> "app.php/' + (![]+[])[+!+[]] + 'dsview/1",
+					'U_PHPBB_ADS_VIEWS'	=> "app.php/' + (![]+[])[+!+[]] + 'dsview/1",
 				));
 		}
 


### PR DESCRIPTION
- [ ] 1) Please add a screenshot to the CDB so users can see what the extensions does at a glance.

- [x] 2) From ad/manager.php:
```
			/* All other cases should use the default
			case 'mssql':
			case 'mssql_odbc':
			case 'mssqlnative':
			case 'mysql':
			case 'mysqli':*/
			default:
```
Remove commented code. If you want to make your point, just have it as a list.

- [x] 3) `phpbb.alert('{{ lang('INFORMATION') }}', '{{ lang('NO_FILE_SELECTED') }}');`
Language items need to be escaped in javascript.

- [x] 4) `var u_phpbb_ads_click = '{{ UA_PHPBB_ADS_CLICK }}';`
Variables with the A prefix are ment for addslashed variables, but this variable is not addslashed. It is also not escaped properly for it to be used in javascript.

- [x] 5) I would like to see the CSRF formkey check in the admin input be moved to the admin controller, to have it clear they are both done and handled correctly.

- [x] 6) It might be a good idea to look into why phpBB decided to serve all uploaded images, like avatars and attachments by downloads/file.php instead of direct linking them. I know it was for security reasons, however I can't exactly remember why.

### Comments
**5)** I have rather moved `add_form_key` to input than breaking nicely coupled validation into two classes.

**6)** It's not applicable to us. The main problem is that it is [bound to attachments](https://github.com/phpbb/phpbb/blob/master/phpBB/download/file.php#L167), so in case admin disallows attachments, but wants to display ads, this method would effectively disallow any banner to display.