### PR TITLE
Move date formatting to Twig

### DIFF
--- a/adm/style/manage_ads.html
+++ b/adm/style/manage_ads.html
@@ -88,7 +88,7 @@
 			</dl>
 			<dl>
 				<dt><label for="ad_priority">{{ lang('AD_PRIORITY') ~ lang('COLON') }}</label><br /><span>{{ lang('AD_PRIORITY_EXPLAIN') }}</span></dt>
-				<dd><input type="number" id="ad_priority" name="ad_priority" value="{% if AD_PRIORITY %}{{ AD_PRIORITY }}{% else %}{{ constant('\\phpbb\\ads\\ext::DEFAULT_PRIORITY') }}{% endif %}" min="1" max="10" /></dd>
+				<dd><input type="number" id="ad_priority" name="ad_priority" value="{{ AD_PRIORITY ?: constant('\\phpbb\\ads\\ext::DEFAULT_PRIORITY') }}" min="1" max="10" /></dd>
 			</dl>
 		</fieldset>
 		<fieldset>

--- a/adm/style/manage_ads.html
+++ b/adm/style/manage_ads.html
@@ -108,7 +108,7 @@
 			</dl>
 			<dl>
 				<dt><label for="ad_end_date">{{ lang('AD_END_DATE') ~ lang('COLON') }}</label><br /><span>{{ lang('AD_END_DATE_EXPLAIN') }}</span></dt>
-				<dd><input class="text" id="ad_end_date" name="ad_end_date" value="{{ AD_END_DATE }}" size="20" maxlength="20" /></dd>
+				<dd><input class="text" id="ad_end_date" name="ad_end_date" value="{{ AD_END_DATE ? AD_END_DATE|date(constant('\\phpbb\\ads\\controller\\admin_input::DATE_FORMAT')) }}" size="20" maxlength="20" /></dd>
 			</dl>
 		</fieldset>
 		<fieldset class="submit-buttons">
@@ -142,7 +142,7 @@
 			</tr>
 		</thead>
 		<tbody>
-			{% set NOW = "now"|date("Y-m-d") %}
+			{% set NOW = "now"|date("U") %}
 			{% for list in [
 				{
 					'heading': lang('ACTIVE_ADS'),
@@ -163,7 +163,7 @@
 							<td>{{ ad.PRIORITY }}</td>
 							<td>
 								{% if ad.END_DATE < NOW %}<strong class="error">{% endif %}
-									{{ ad.END_DATE }}
+									{{ ad.END_DATE ? ad.END_DATE|date(constant('\\phpbb\\ads\\controller\\admin_input::DATE_FORMAT')) }}
 								{% if ad.END_DATE < NOW %}</strong>{% endif %}
 							</td>
 							{% if S_VIEWS_ENABLED %}

--- a/adm/style/manage_ads.html
+++ b/adm/style/manage_ads.html
@@ -88,7 +88,7 @@
 			</dl>
 			<dl>
 				<dt><label for="ad_priority">{{ lang('AD_PRIORITY') ~ lang('COLON') }}</label><br /><span>{{ lang('AD_PRIORITY_EXPLAIN') }}</span></dt>
-				<dd><input type="number" id="ad_priority" name="ad_priority" value="{% if AD_PRIORITY %}{{ AD_PRIORITY }}{% else %}{{ constant('\\phpbb\\ads\\controller\\admin_input::DEFAULT_PRIORITY') }}{% endif %}" min="1" max="10" /></dd>
+				<dd><input type="number" id="ad_priority" name="ad_priority" value="{% if AD_PRIORITY %}{{ AD_PRIORITY }}{% else %}{{ constant('\\phpbb\\ads\\ext::DEFAULT_PRIORITY') }}{% endif %}" min="1" max="10" /></dd>
 			</dl>
 		</fieldset>
 		<fieldset>
@@ -108,7 +108,7 @@
 			</dl>
 			<dl>
 				<dt><label for="ad_end_date">{{ lang('AD_END_DATE') ~ lang('COLON') }}</label><br /><span>{{ lang('AD_END_DATE_EXPLAIN') }}</span></dt>
-				<dd><input class="text" id="ad_end_date" name="ad_end_date" value="{{ AD_END_DATE ? AD_END_DATE|date(constant('\\phpbb\\ads\\controller\\admin_input::DATE_FORMAT')) }}" size="20" maxlength="20" /></dd>
+				<dd><input class="text" id="ad_end_date" name="ad_end_date" value="{{ AD_END_DATE ? AD_END_DATE|date(constant('\\phpbb\\ads\\ext::DATE_FORMAT')) }}" size="20" maxlength="20" /></dd>
 			</dl>
 		</fieldset>
 		<fieldset class="submit-buttons">
@@ -163,7 +163,7 @@
 							<td>{{ ad.PRIORITY }}</td>
 							<td>
 								{% if ad.END_DATE < NOW %}<strong class="error">{% endif %}
-									{{ ad.END_DATE ? ad.END_DATE|date(constant('\\phpbb\\ads\\controller\\admin_input::DATE_FORMAT')) }}
+									{{ ad.END_DATE ? ad.END_DATE|date(constant('\\phpbb\\ads\\ext::DATE_FORMAT')) }}
 								{% if ad.END_DATE < NOW %}</strong>{% endif %}
 							</td>
 							{% if S_VIEWS_ENABLED %}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "phpbb-extension",
 	"description": "An extension for phpBB that allows administrators to manage and display advertisements on their forums.",
 	"homepage": "https://www.phpbb.com",
-	"version": "1.0.2-dev",
+	"version": "1.0.3-dev",
 	"keywords": ["phpbb", "extension", "advertisement"],
 	"license": "GPL-2.0",
 	"authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0496b96025b6541b12ddaa370efdbbd0",
+    "content-hash": "e0607c04a961eda09cf898638aa7b66b",
     "packages": [
         {
             "name": "composer/installers",

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -329,7 +329,7 @@ class admin_controller
 			$this->template->assign_block_vars($ad_expired ? 'expired' : 'ads', array(
 				'NAME'         => $row['ad_name'],
 				'PRIORITY'     => $row['ad_priority'],
-				'END_DATE'     => $this->helper->prepare_end_date($row['ad_end_date']),
+				'END_DATE'     => $row['ad_end_date'],
 				'VIEWS'        => $row['ad_views'],
 				'CLICKS'       => $row['ad_clicks'],
 				'VIEWS_LIMIT'  => $row['ad_views_limit'],

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -10,7 +10,7 @@
 
 namespace phpbb\ads\controller;
 
-use phpbb\ads\controller\admin_input as input;
+use phpbb\ads\ext;
 
 /**
 * Admin controller
@@ -200,7 +200,7 @@ class admin_controller
 			'S_ADD_AD'				=> true,
 			'U_BACK'				=> $this->u_action,
 			'U_ACTION'				=> "{$this->u_action}&amp;action=add",
-			'PICKER_DATE_FORMAT'	=> input::DATE_FORMAT,
+			'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 			'U_FIND_USERNAME'		=> $this->helper->get_find_username_link(),
 		));
 	}
@@ -236,7 +236,7 @@ class admin_controller
 			'EDIT_ID'				=> $ad_id,
 			'U_BACK'				=> $this->u_action,
 			'U_ACTION'				=> "{$this->u_action}&amp;action=edit&amp;id=$ad_id",
-			'PICKER_DATE_FORMAT'	=> input::DATE_FORMAT,
+			'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 			'U_FIND_USERNAME'		=> $this->helper->get_find_username_link(),
 		));
 		$this->helper->assign_data($this->data, $this->input->get_errors());

--- a/controller/admin_helper.php
+++ b/controller/admin_helper.php
@@ -79,7 +79,7 @@ class admin_helper
 			'AD_NOTE'         => $data['ad_note'],
 			'AD_CODE'         => $data['ad_code'],
 			'AD_ENABLED'      => $data['ad_enabled'],
-			'AD_END_DATE'     => $this->prepare_end_date($data['ad_end_date']),
+			'AD_END_DATE'     => $data['ad_end_date'],
 			'AD_PRIORITY'     => $data['ad_priority'],
 			'AD_VIEWS_LIMIT'  => $data['ad_views_limit'],
 			'AD_CLICKS_LIMIT' => $data['ad_clicks_limit'],
@@ -126,27 +126,6 @@ class admin_helper
 	public function get_find_username_link()
 	{
 		return append_sid("{$this->root_path}memberlist.{$this->php_ext}", 'mode=searchuser&amp;form=acp_admanagement_add&amp;field=ad_owner&amp;select_single=true');
-	}
-
-	/**
-	 * Prepare end date for display
-	 *
-	 * @param	mixed	$end_date	End date.
-	 * @return	string	End date prepared for display.
-	 */
-	public function prepare_end_date($end_date)
-	{
-		if (empty($end_date))
-		{
-			return '';
-		}
-
-		if (is_numeric($end_date))
-		{
-			return $this->user->format_date($end_date, input::DATE_FORMAT);
-		}
-
-		return (string) $end_date;
 	}
 
 	/**

--- a/controller/admin_helper.php
+++ b/controller/admin_helper.php
@@ -10,8 +10,6 @@
 
 namespace phpbb\ads\controller;
 
-use phpbb\ads\controller\admin_input as input;
-
 /**
  * Admin helper
  */

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -10,15 +10,13 @@
 
 namespace phpbb\ads\controller;
 
+use phpbb\ads\ext;
+
 /**
  * Admin input
  */
 class admin_input
 {
-	const MAX_NAME_LENGTH = 255;
-	const DATE_FORMAT = 'Y-m-d';
-	const DEFAULT_PRIORITY = 5;
-
 	/** @var \phpbb\user */
 	protected $user;
 
@@ -86,7 +84,7 @@ class admin_input
 			'ad_enabled'      => $this->request->variable('ad_enabled', 0),
 			'ad_locations'    => $this->request->variable('ad_locations', array('')),
 			'ad_end_date'     => $this->request->variable('ad_end_date', ''),
-			'ad_priority'     => $this->request->variable('ad_priority', self::DEFAULT_PRIORITY),
+			'ad_priority'     => $this->request->variable('ad_priority', ext::DEFAULT_PRIORITY),
 			'ad_views_limit'  => $this->request->variable('ad_views_limit', 0),
 			'ad_clicks_limit' => $this->request->variable('ad_clicks_limit', 0),
 			'ad_owner'        => $this->request->variable('ad_owner', '', true),
@@ -165,9 +163,9 @@ class admin_input
 		{
 			$this->errors[] = 'AD_NAME_REQUIRED';
 		}
-		if (truncate_string($ad_name, self::MAX_NAME_LENGTH) !== $ad_name)
+		if (truncate_string($ad_name, ext::MAX_NAME_LENGTH) !== $ad_name)
 		{
-			$this->errors[] = $this->language->lang('AD_NAME_TOO_LONG', self::MAX_NAME_LENGTH);
+			$this->errors[] = $this->language->lang('AD_NAME_TOO_LONG', ext::MAX_NAME_LENGTH);
 		}
 	}
 
@@ -254,7 +252,7 @@ class admin_input
 	 */
 	protected function end_date_to_timestamp($end_date)
 	{
-		return (int) $this->user->get_timestamp_from_format(self::DATE_FORMAT, $end_date);
+		return (int) $this->user->get_timestamp_from_format(ext::DATE_FORMAT, $end_date);
 	}
 
 	/**

--- a/ext.php
+++ b/ext.php
@@ -12,6 +12,10 @@ namespace phpbb\ads;
 
 class ext extends \phpbb\extension\base
 {
+	const DATE_FORMAT = 'Y-m-d';
+	const MAX_NAME_LENGTH = 255;
+	const DEFAULT_PRIORITY = 5;
+
 	/**
 	 * {@inheritdoc}
 	 */

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -1097,7 +1097,7 @@ class admin_controller_test extends \phpbb_database_test_case
 			->with($rows[0])
 			->willReturn(false);
 
-		$this->helper->expects($this->at(2))
+		$this->helper->expects($this->at(1))
 			->method('is_expired')
 			->with($rows[1])
 			->willReturn(true);

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -12,7 +12,8 @@ namespace phpbb\ads\controller;
 
 require_once __DIR__ . '/../../../../../includes/functions_acp.php';
 
-use \phpbb\ads\controller\admin_input_test as input;
+use phpbb\ads\controller\admin_input_test as input;
+use phpbb\ads\ext;
 
 class admin_controller_test extends \phpbb_database_test_case
 {
@@ -388,7 +389,7 @@ class admin_controller_test extends \phpbb_database_test_case
 				'S_ADD_AD'				=> true,
 				'U_BACK'				=> $this->u_action,
 				'U_ACTION'				=> "{$this->u_action}&amp;action=add",
-				'PICKER_DATE_FORMAT'	=> \phpbb\ads\controller\admin_input::DATE_FORMAT,
+				'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 				'U_FIND_USERNAME'		=> 'u_find_username',
 			));
 
@@ -722,7 +723,7 @@ class admin_controller_test extends \phpbb_database_test_case
 					'EDIT_ID'				=> $ad_id,
 					'U_BACK'				=> $this->u_action,
 					'U_ACTION'				=> "{$this->u_action}&amp;action=edit&amp;id=" . $ad_id,
-					'PICKER_DATE_FORMAT'	=> \phpbb\ads\controller\admin_input::DATE_FORMAT,
+					'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 					'U_FIND_USERNAME'		=> 'u_find_username',
 				));
 
@@ -783,7 +784,7 @@ class admin_controller_test extends \phpbb_database_test_case
 				'EDIT_ID'				=> 1,
 				'U_BACK'				=> $this->u_action,
 				'U_ACTION'				=> "{$this->u_action}&amp;action=edit&amp;id=1",
-				'PICKER_DATE_FORMAT'	=> \phpbb\ads\controller\admin_input::DATE_FORMAT,
+				'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 				'U_FIND_USERNAME'		=> 'u_find_username',
 			));
 
@@ -888,7 +889,7 @@ class admin_controller_test extends \phpbb_database_test_case
 					'EDIT_ID'				=> 1,
 					'U_BACK'				=> $this->u_action,
 					'U_ACTION'				=> "{$this->u_action}&amp;action=edit&amp;id=1",
-					'PICKER_DATE_FORMAT'	=> \phpbb\ads\controller\admin_input::DATE_FORMAT,
+					'PICKER_DATE_FORMAT'	=> ext::DATE_FORMAT,
 					'U_FIND_USERNAME'		=> 'u_find_username',
 				));
 

--- a/tests/controller/admin_helper_test.php
+++ b/tests/controller/admin_helper_test.php
@@ -286,21 +286,6 @@ class admin_helper_test extends \phpbb_database_test_case
 	}
 
 	/**
-	 * Data for test_prepare_end_date
-	 *
-	 * @return array Array of test data
-	 */
-	public function prepare_end_date_data()
-	{
-		return array(
-			array('', ''),
-			array(1, '1970-01-01'),
-			array('1', '1970-01-01'),
-			array('a', 'a'),
-		);
-	}
-
-	/**
 	 * Data for test_is_expired
 	 *
 	 * @return array Array of test data

--- a/tests/controller/admin_helper_test.php
+++ b/tests/controller/admin_helper_test.php
@@ -122,7 +122,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '0',
-				  ), '', '', array('AD_PRIORITY_INVALID'), true, 'AD_PRIORITY_INVALID'),
+				  ), '', array('AD_PRIORITY_INVALID'), true, 'AD_PRIORITY_INVALID'),
 			array(array(
 					  'ad_name'			=> 'Ad Name #1',
 					  'ad_note'			=> 'Ad Note #1',
@@ -133,7 +133,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '0',
-				  ), '', '', array('AD_PRIORITY_INVALID', 'AD_NAME_REQUIRED'), true, 'AD_PRIORITY_INVALID<br />AD_NAME_REQUIRED'),
+				  ), '', array('AD_PRIORITY_INVALID', 'AD_NAME_REQUIRED'), true, 'AD_PRIORITY_INVALID<br />AD_NAME_REQUIRED'),
 			array(array(
 					  'ad_name'			=> 'Ad Name #2',
 					  'ad_note'			=> 'Ad Note #2',
@@ -144,7 +144,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '99',
-				  ), '1970-01-01', '', array(), false, ''),
+				  ), '', array(), false, ''),
 			array(array(
 					  'ad_name'			=> 'Ad Name #2',
 					  'ad_note'			=> 'Ad Note #2',
@@ -155,7 +155,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '99',
-				  ), '1970-01-01', '', array(), false, ''),
+				  ), '', array(), false, ''),
 			array(array(
 					  'ad_name'			=> 'Ad Name #3',
 					  'ad_note'			=> 'Ad Note #3',
@@ -166,7 +166,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '2',
-				  ), '2017-01-01', 'admin', array(), false, ''),
+				  ), 'admin', array(), false, ''),
 		);
 	}
 
@@ -175,7 +175,7 @@ class admin_helper_test extends \phpbb_database_test_case
 	 *
 	 * @dataProvider assign_data_data
 	 */
-	public function test_assign_data($data, $end_date, $owner, $errors, $s_errors, $error_msg)
+	public function test_assign_data($data, $owner, $errors, $s_errors, $error_msg)
 	{
 		$helper = $this->get_helper();
 
@@ -193,7 +193,7 @@ class admin_helper_test extends \phpbb_database_test_case
 				'AD_NOTE'         => $data['ad_note'],
 				'AD_CODE'         => $data['ad_code'],
 				'AD_ENABLED'      => $data['ad_enabled'],
-				'AD_END_DATE'     => $end_date,
+				'AD_END_DATE'     => $data['ad_end_date'],
 				'AD_PRIORITY'     => $data['ad_priority'],
 				'AD_VIEWS_LIMIT'  => $data['ad_views_limit'],
 				'AD_CLICKS_LIMIT' => $data['ad_clicks_limit'],
@@ -298,18 +298,6 @@ class admin_helper_test extends \phpbb_database_test_case
 			array('1', '1970-01-01'),
 			array('a', 'a'),
 		);
-	}
-
-	/**
-	 * Test prepare_end_date()
-	 *
-	 * @dataProvider prepare_end_date_data
-	 */
-	public function test_prepare_end_date($end_date, $expected)
-	{
-		$helper = $this->get_helper();
-		$result = $helper->prepare_end_date($end_date);
-		$this->assertEquals($expected, $result);
 	}
 
 	/**

--- a/tests/event/clicks_test.php
+++ b/tests/event/clicks_test.php
@@ -34,21 +34,18 @@ class clicks_test extends main_listener_base
 	{
 		$this->config['phpbb_ads_enable_clicks'] = $enable_clicks;
 
-		if ($enable_clicks)
-		{
-			$this->controller_helper->expects($this->once())
-				->method('route')
-				->with('phpbb_ads_click', array('data' => 0))
-				->willReturn('app.php/adsclick/0');
+		$this->controller_helper->expects($enable_clicks ? $this->once() : $this->never())
+			->method('route')
+			->with('phpbb_ads_click', array('data' => 0))
+			->willReturn('app.php/adsclick/0');
 
-			$this->template
-				->expects($this->once())
-				->method('assign_vars')
-				->with(array(
-					'U_PHPBB_ADS_CLICK'		=> 'app.php/adsclick/0',
-					'S_PHPBB_ADS_ENABLE_CLICKS'	=> true,
-				));
-		}
+		$this->template
+			->expects($enable_clicks ? $this->once() : $this->never())
+			->method('assign_vars')
+			->with(array(
+				'U_PHPBB_ADS_CLICK'		=> 'app.php/adsclick/0',
+				'S_PHPBB_ADS_ENABLE_CLICKS'	=> true,
+			));
 
 		$dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
 		$dispatcher->addListener('core.page_header_after', array($this->get_listener(), 'clicks'));


### PR DESCRIPTION
We should just handle the end date as it is stored, as a timestamp. When it is time to display it to the user, we can use the date formatting features already built in to TWIG to convert the timestamp to a nice date, and we can use our constant for formatting the date to keep it nice and consistent wherever we display it.

@senky 