### PR TITLE
Use the user loader

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -40,6 +40,7 @@ services:
         class: phpbb\ads\controller\admin_helper
         arguments:
             - '@user'
+            - '@user_loader'
             - '@language'
             - '@template'
             - '@log'
@@ -51,6 +52,7 @@ services:
         class: phpbb\ads\controller\admin_input
         arguments:
             - '@user'
+            - '@user_loader'
             - '@language'
             - '@request'
             - '@phpbb.ads.banner.banner'

--- a/config/services.yml
+++ b/config/services.yml
@@ -33,8 +33,6 @@ services:
             - '@phpbb.ads.admin.input'
             - '@phpbb.ads.admin.helper'
             - '@phpbb.ads.analyser.manager'
-            - '%core.root_path%'
-            - '%core.php_ext%'
 
     phpbb.ads.admin.helper:
         class: phpbb\ads\controller\admin_helper

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -66,10 +66,8 @@ class admin_controller
 	 * @param \phpbb\ads\controller\admin_input  $input        Admin input object
 	 * @param \phpbb\ads\controller\admin_helper $helper       Admin helper object
 	 * @param \phpbb\ads\analyser\manager        $analyser     Ad code analyser object
-	 * @param string                             $root_path    phpBB root path
-	 * @param string                             $php_ext      PHP extension
 	 */
-	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, \phpbb\request\request $request, \phpbb\ads\ad\manager $manager, \phpbb\config\db_text $config_text, \phpbb\config\config $config, \phpbb\group\helper $group_helper, \phpbb\ads\controller\admin_input $input, \phpbb\ads\controller\admin_helper $helper, \phpbb\ads\analyser\manager $analyser, $root_path, $php_ext)
+	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, \phpbb\request\request $request, \phpbb\ads\ad\manager $manager, \phpbb\config\db_text $config_text, \phpbb\config\config $config, \phpbb\group\helper $group_helper, \phpbb\ads\controller\admin_input $input, \phpbb\ads\controller\admin_helper $helper, \phpbb\ads\analyser\manager $analyser)
 	{
 		$this->template = $template;
 		$this->language = $language;
@@ -353,7 +351,7 @@ class admin_controller
 	 *  - analyse ad code
 	 *  - submit form (either add or edit an ad)
 	 *
-	 * @return	mixed	Action name or false when no action was submitted
+	 * @return	string|false	Action name or false when no action was submitted
 	 */
 	protected function get_submitted_action()
 	{

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -82,11 +82,6 @@ class admin_controller
 		$this->helper = $helper;
 		$this->analyser = $analyser;
 
-		if (!function_exists('user_get_id_name'))
-		{
-			include $root_path . 'includes/functions_user.' . $php_ext;
-		}
-
 		$this->language->add_lang('posting'); // Used by banner_upload() file errors
 		$this->language->add_lang('acp', 'phpbb/ads');
 

--- a/controller/admin_helper.php
+++ b/controller/admin_helper.php
@@ -86,7 +86,7 @@ class admin_helper
 			'AD_PRIORITY'     => $data['ad_priority'],
 			'AD_VIEWS_LIMIT'  => $data['ad_views_limit'],
 			'AD_CLICKS_LIMIT' => $data['ad_clicks_limit'],
-			'AD_OWNER'        => $this->get_username((int) $data['ad_owner']),
+			'AD_OWNER'        => $this->get_username($data['ad_owner']),
 		));
 	}
 

--- a/controller/admin_helper.php
+++ b/controller/admin_helper.php
@@ -18,6 +18,9 @@ class admin_helper
 	/** @var \phpbb\user */
 	protected $user;
 
+	/** @var \phpbb\user_loader */
+	protected $user_loader;
+
 	/** @var \phpbb\language\language */
 	protected $language;
 
@@ -39,17 +42,19 @@ class admin_helper
 	/**
 	 * Constructor
 	 *
-	 * @param \phpbb\user						$user				User object
-	 * @param \phpbb\language\language          $language           Language object
-	 * @param \phpbb\template\template			$template			Template object
-	 * @param \phpbb\log\log					$log				The phpBB log system
-	 * @param \phpbb\ads\location\manager		$location_manager	Template location manager object
-	 * @param string							$root_path			phpBB root path
-	 * @param string							$php_ext			PHP extension
+	 * @param \phpbb\user                 $user             User object
+	 * @param \phpbb\user_loader          $user_loader      User loader object
+	 * @param \phpbb\language\language    $language         Language object
+	 * @param \phpbb\template\template    $template         Template object
+	 * @param \phpbb\log\log              $log              The phpBB log system
+	 * @param \phpbb\ads\location\manager $location_manager Template location manager object
+	 * @param string                      $root_path        phpBB root path
+	 * @param string                      $php_ext          PHP extension
 	 */
-	public function __construct(\phpbb\user $user, \phpbb\language\language $language, \phpbb\template\template $template, \phpbb\log\log $log, \phpbb\ads\location\manager $location_manager, $root_path, $php_ext)
+	public function __construct(\phpbb\user $user, \phpbb\user_loader $user_loader, \phpbb\language\language $language, \phpbb\template\template $template, \phpbb\log\log $log, \phpbb\ads\location\manager $location_manager, $root_path, $php_ext)
 	{
 		$this->user = $user;
+		$this->user_loader = $user_loader;
 		$this->language = $language;
 		$this->template = $template;
 		$this->log = $log;
@@ -81,7 +86,7 @@ class admin_helper
 			'AD_PRIORITY'     => $data['ad_priority'],
 			'AD_VIEWS_LIMIT'  => $data['ad_views_limit'],
 			'AD_CLICKS_LIMIT' => $data['ad_clicks_limit'],
-			'AD_OWNER'        => $this->prepare_ad_owner($data['ad_owner']),
+			'AD_OWNER'        => $this->get_username((int) $data['ad_owner']),
 		));
 	}
 
@@ -154,25 +159,19 @@ class admin_helper
 
 	/**
 	 * Prepare ad owner for display. Method takes user_id
-	 * of the ad owner and returns his/her username.
+	 * of the ad owner and returns username.
 	 *
-	 * @param	int		$ad_owner	User ID
-	 * @return	string	Username belonging to $ad_owner.
+	 * @param	int		$user_id	User ID
+	 * @return	string	Username belonging to $user_id.
 	 */
-	protected function prepare_ad_owner($ad_owner)
+	protected function get_username($user_id)
 	{
-		$user_id = array($ad_owner);
-		$user_name = array();
-
-		// Returns false when no errors occur trying to find the user
-		if (false === user_get_id_name($user_id, $user_name))
+		if (!$user_id)
 		{
-			if (empty($user_name))
-			{
-				return $user_id[0];
-			}
-			return $user_name[(int) $user_id[0]];
+			return '';
 		}
-		return '';
+
+		$this->user_loader->load_users(array($user_id));
+		return $this->user_loader->get_username($user_id, 'username');
 	}
 }

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -256,7 +256,7 @@ class admin_input
 	 */
 	protected function validate_ad_owner($ad_owner)
 	{
-		if (!empty($ad_owner) && ANONYMOUS === ($ad_owner = $this->user_loader->load_user_by_username($ad_owner)))
+		if (!empty($ad_owner) && ANONYMOUS === ($ad_owner = (int) $this->user_loader->load_user_by_username($ad_owner)))
 		{
 			$this->errors[] = 'AD_OWNER_INVALID';
 		}

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -154,6 +154,9 @@ class admin_input
 	/**
 	 * Validate advertisement name
 	 *
+	 * Ad name is required and must not be empty. Ad name must
+	 * also be less than 255 characters.
+	 *
 	 * @param string $ad_name Advertisement name
 	 * @return string Advertisement name
 	 */
@@ -175,6 +178,8 @@ class admin_input
 	/**
 	 * Validate advertisement code
 	 *
+	 * Ad code should not contain 4-byte Emoji characters.
+	 *
 	 * @param string $ad_code Advertisement code
 	 * @return string Advertisement code
 	 */
@@ -191,6 +196,10 @@ class admin_input
 
 	/**
 	 * Validate advertisement end date
+	 *
+	 * End date must use the expected format of YYYY-MM-DD.
+	 * If the date is valid, convert it to a timestamp and then
+	 * make sure the timestamp is less than the current time.
 	 *
 	 * @param string $end_date Advertisement end date
 	 * @return int The end date converted to timestamp if valid, otherwise 0.
@@ -218,6 +227,8 @@ class admin_input
 	/**
 	 * Validate advertisement priority
 	 *
+	 * Ad priority must be an integer between 1 and 10.
+	 *
 	 * @param int $ad_priority Advertisement priority
 	 * @return int Advertisement priority
 	 */
@@ -233,6 +244,8 @@ class admin_input
 
 	/**
 	 * Validate advertisement views limit
+	 *
+	 * Clicks must be a positive integer.
 	 *
 	 * @param int $ad_views_limit Advertisement views limit
 	 * @return int Advertisement views limit
@@ -250,6 +263,8 @@ class admin_input
 	/**
 	 * Validate advertisement clicks limit
 	 *
+	 * Clicks must be a positive integer.
+	 *
 	 * @param int $ad_clicks_limit Advertisement clicks limit
 	 * @return int Advertisement clicks limit
 	 */
@@ -265,6 +280,9 @@ class admin_input
 
 	/**
 	 * Validate advertisement owner
+	 *
+	 * If ad owner name given, get their ID. If the ID returned is ANONYMOUS,
+	 * set an error because the user name given doesn't exist.
 	 *
 	 * @param string $ad_owner User name
 	 * @return int User id if user exists, otherwise 0.

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -175,6 +175,23 @@ class admin_input
 	}
 
 	/**
+	 * Validate advertisement code
+	 *
+	 * @param string $ad_code Advertisement code
+	 * @return string Advertisement code
+	 */
+	protected function validate_ad_code($ad_code)
+	{
+		if (preg_match_all('/[\x{10000}-\x{10FFFF}]/u', $ad_code, $matches))
+		{
+			$characters = implode(' ', $matches[0]);
+			$this->errors[] = $this->language->lang('AD_CODE_ILLEGAL_CHARS', $characters);
+		}
+
+		return $ad_code;
+	}
+
+	/**
 	 * Validate advertisement end date
 	 *
 	 * @param string $end_date Advertisement end date

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -102,16 +102,14 @@ class admin_input
 		}
 
 		// Validate each property. Some validators update the property value. Errors are added to $this->errors.
-		foreach ($data as $prop_name => &$prop_val)
+		foreach ($data as $prop_name => $prop_val)
 		{
 			$method = 'validate_' . $prop_name;
 			if (method_exists($this, $method))
 			{
-				$prop_val = $this->{$method}($prop_val);
+				$data[$prop_name] = $this->{$method}($prop_val);
 			}
 		}
-
-		unset($prop_val);
 
 		return $data;
 	}

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -273,12 +273,13 @@ class admin_input
 	 */
 	protected function validate_ad_owner($ad_owner)
 	{
-		if (!empty($ad_owner) && ANONYMOUS === ($ad_owner = (int) $this->user_loader->load_user_by_username($ad_owner)))
+		$user_id = 0;
+		if (!empty($ad_owner) && ANONYMOUS === ($user_id = (int) $this->user_loader->load_user_by_username($ad_owner)))
 		{
 			$this->errors[] = 'AD_OWNER_INVALID';
 		}
 
-		return ANONYMOUS === $ad_owner ? 0 : (int) $ad_owner;
+		return ANONYMOUS !== $user_id ? $user_id : 0;
 	}
 
 	/**

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -104,9 +104,10 @@ class admin_input
 		// Validate each property. Some validators update the property value. Errors are added to $this->errors.
 		foreach ($data as $prop_name => &$prop_val)
 		{
-			if (method_exists($this, 'validate_' . $prop_name))
+			$method = 'validate_' . $prop_name;
+			if (method_exists($this, $method))
 			{
-				$prop_val = $this->{'validate_' . $prop_name}($prop_val);
+				$prop_val = $this->{$method}($prop_val);
 			}
 		}
 

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -98,7 +98,7 @@ class admin_input
 		// Validate form key
 		if (!check_form_key('phpbb_ads'))
 		{
-			$this->errors[] = $this->language->lang('FORM_INVALID');
+			$this->errors[] = 'FORM_INVALID';
 		}
 
 		// Validate each property. Some validators update the property value. Errors are added to $this->errors.

--- a/language/en/acp.php
+++ b/language/en/acp.php
@@ -67,6 +67,7 @@ $lang = array_merge($lang, array(
 
 	'AD_NAME_REQUIRED'			=> 'Name is required.',
 	'AD_NAME_TOO_LONG'			=> 'Name length is limited to %d characters.',
+	'AD_CODE_ILLEGAL_CHARS'		=> 'Ad code contains the following unsupported characters: %s',
 	'AD_END_DATE_INVALID'		=> 'The end date is invalid or has already expired.',
 	'AD_PRIORITY_INVALID'		=> 'The priority is invalid. Please set a number between 1 and 10.',
 	'AD_VIEWS_LIMIT_INVALID'	=> 'The views limit is invalid. Please set a non-negative number.',

--- a/tests/analyser/analyser_base.php
+++ b/tests/analyser/analyser_base.php
@@ -27,7 +27,7 @@ class analyser_base extends \phpbb_test_case
 	/**
 	 * {@inheritDoc}
 	 */
-	static protected function setup_extensions()
+	protected static function setup_extensions()
 	{
 		return array('phpbb/ads');
 	}
@@ -58,7 +58,7 @@ class analyser_base extends \phpbb_test_case
 		foreach ($tests as $test)
 		{
 			$class = "\\phpbb\\ads\\analyser\\test\\$test";
-			if ($test == 'untrusted_connection')
+			if ($test === 'untrusted_connection')
 			{
 				$analyser_tests['phpbb.ads.analyser.test.' . $test] = new $class($this->request);
 			}

--- a/tests/analyser/run_test.php
+++ b/tests/analyser/run_test.php
@@ -132,7 +132,6 @@ class run_test extends analyser_base
 				->method('assign_block_vars');
 		}
 
-
 		$manager->run($ad_code);
 	}
 }

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -23,7 +23,7 @@ class admin_controller_test extends \phpbb_database_test_case
 	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\template\template */
 	protected $template;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\language\language */
+	/** @var \phpbb\language\language */
 	protected $language;
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\request\request */
@@ -456,6 +456,8 @@ class admin_controller_test extends \phpbb_database_test_case
 			'ad_locations'	=> array(),
 		);
 
+		$banner_ad_code = '<!-- BANNER AD CODE -->';
+
 		$this->input->expects($this->once())
 			->method('get_form_data')
 			->willReturn($data);
@@ -463,9 +465,9 @@ class admin_controller_test extends \phpbb_database_test_case
 		$this->input->expects($this->once())
 			->method('banner_upload')
 			->with($data['ad_code'])
-			->willReturn($new_ad_code);
+			->willReturn($banner_ad_code);
 
-		$data['ad_code'] = $new_ad_code;
+		$data['ad_code'] = $banner_ad_code;
 
 		$this->input->expects($this->once())
 			->method('get_errors')

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -110,8 +110,6 @@ class admin_controller_test extends \phpbb_database_test_case
 		$this->analyser = $this->getMockBuilder('\phpbb\ads\analyser\manager')
 			->disableOriginalConstructor()
 			->getMock();
-		$this->root_path = $phpbb_root_path;
-		$this->php_ext = $phpEx;
 
 		$this->u_action = $phpbb_root_path . 'adm/index.php?i=-phpbb-ads-acp-main_module&mode=manage';
 
@@ -136,9 +134,7 @@ class admin_controller_test extends \phpbb_database_test_case
 			$this->group_helper,
 			$this->input,
 			$this->helper,
-			$this->analyser,
-			$this->root_path,
-			$this->php_ext
+			$this->analyser
 		);
 		$controller->set_page_url($this->u_action);
 
@@ -328,9 +324,7 @@ class admin_controller_test extends \phpbb_database_test_case
 				$this->group_helper,
 				$this->input,
 				$this->helper,
-				$this->analyser,
-				$this->root_path,
-				$this->php_ext
+				$this->analyser
 			))
 			->getMock();
 

--- a/tests/controller/admin_helper_test.php
+++ b/tests/controller/admin_helper_test.php
@@ -15,6 +15,9 @@ class admin_helper_test extends \phpbb_database_test_case
 	/** @var \phpbb\user */
 	protected $user;
 
+	/** @var \phpbb\user_loader */
+	protected $user_loader;
+
 	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\language\language */
 	protected $language;
 
@@ -56,20 +59,17 @@ class admin_helper_test extends \phpbb_database_test_case
 	{
 		parent::setUp();
 
-		global $phpbb_root_path, $phpEx;
-		global $db, $phpbb_dispatcher;
+		global $db, $phpbb_dispatcher, $phpbb_root_path, $phpEx;
 
-		if (!function_exists('user_get_id_name'))
-		{
-			include($phpbb_root_path . 'includes/functions_user.' . $phpEx);
-		}
-
-		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
+		// Global variables
+		$db = $this->new_dbal();
+		$phpbb_dispatcher = new \phpbb_mock_event_dispatcher();
 
 		// Load/Mock classes required by the controller class
-		$this->language = new \phpbb\language\language($lang_loader);
+		$this->language = new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx));
 		$this->user = new \phpbb\user($this->language, '\phpbb\datetime');
 		$this->user->timezone = new \DateTimeZone('UTC');
+		$this->user_loader = new \phpbb\user_loader($db, $phpbb_root_path, $phpEx, 'phpbb_users');
 		$this->template = $this->getMock('\phpbb\template\template');
 		$this->log = $this->getMockBuilder('\phpbb\log\log')
 			->disableOriginalConstructor()
@@ -79,9 +79,6 @@ class admin_helper_test extends \phpbb_database_test_case
 			->getMock();
 		$this->root_path = $phpbb_root_path;
 		$this->php_ext = $phpEx;
-
-		$db = $this->new_dbal();
-		$phpbb_dispatcher = new \phpbb_mock_event_dispatcher();
 	}
 
 	/**
@@ -93,6 +90,7 @@ class admin_helper_test extends \phpbb_database_test_case
 	{
 		$helper = new \phpbb\ads\controller\admin_helper(
 			$this->user,
+			$this->user_loader,
 			$this->language,
 			$this->template,
 			$this->log,
@@ -144,7 +142,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '99',
-				  ), '', array(), false, ''),
+				  ), 'Anonymous', array(), false, ''),
 			array(array(
 					  'ad_name'			=> 'Ad Name #2',
 					  'ad_note'			=> 'Ad Note #2',
@@ -155,7 +153,7 @@ class admin_helper_test extends \phpbb_database_test_case
 					  'ad_views_limit'	=> '0',
 					  'ad_clicks_limit'	=> '0',
 					  'ad_owner'			=> '99',
-				  ), '', array(), false, ''),
+				  ), 'Anonymous', array(), false, ''),
 			array(array(
 					  'ad_name'			=> 'Ad Name #3',
 					  'ad_note'			=> 'Ad Note #3',

--- a/tests/controller/admin_input_test.php
+++ b/tests/controller/admin_input_test.php
@@ -20,6 +20,9 @@ class admin_input_test extends \phpbb_database_test_case
 	/** @var \phpbb\user */
 	protected $user;
 
+	/** @var \phpbb\user_loader */
+	protected $user_loader;
+
 	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\language\language */
 	protected $language;
 
@@ -52,24 +55,22 @@ class admin_input_test extends \phpbb_database_test_case
 	{
 		parent::setUp();
 
-		global $phpbb_root_path, $phpEx;
-		global $db;
+		global $db, $phpbb_root_path, $phpEx;
 
-		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
+		// Global variables
+		$db = $this->new_dbal();
 
 		// Load/Mock classes required by the controller class
-		$this->language = new \phpbb\language\language($lang_loader);
+		$this->language = new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx));
 		$this->user = new \phpbb\user($this->language, '\phpbb\datetime');
 		$this->user->timezone = new \DateTimeZone('UTC');
+		$this->user_loader = new \phpbb\user_loader($db, $phpbb_root_path, $phpEx, 'phpbb_users');
 		$this->request = $this->getMockBuilder('\phpbb\request\request')
 			->disableOriginalConstructor()
 			->getMock();
 		$this->banner = $this->getMockBuilder('\phpbb\ads\banner\banner')
 			->disableOriginalConstructor()
 			->getMock();
-
-		// Global variables
-		$db = $this->new_dbal();
 	}
 
 	/**
@@ -81,6 +82,7 @@ class admin_input_test extends \phpbb_database_test_case
 	{
 		$input = new \phpbb\ads\controller\admin_input(
 			$this->user,
+			$this->user_loader,
 			$this->language,
 			$this->request,
 			$this->banner

--- a/tests/controller/admin_input_test.php
+++ b/tests/controller/admin_input_test.php
@@ -100,6 +100,7 @@ class admin_input_test extends \phpbb_database_test_case
 			array(false, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['FORM_INVALID']),
 			array(true, ['', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['AD_NAME_REQUIRED']),
 			array(true, [str_repeat('a', 256), 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['AD_NAME_TOO_LONG']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code with emoji 😀', '', '', '', '5', '', '', ''], 0, ['AD_CODE_ILLEGAL_CHARS']),
 			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', 'blah', '5', '', '', ''], 0, ['AD_END_DATE_INVALID']),
 			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '1970-01-01', '5', '', '', ''], 0, ['AD_END_DATE_INVALID']),
 			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '0', '', '', ''], 0, ['AD_PRIORITY_INVALID']),

--- a/tests/controller/admin_input_test.php
+++ b/tests/controller/admin_input_test.php
@@ -10,8 +10,6 @@
 
 namespace phpbb\ads\controller;
 
-require_once __DIR__ . '/../../../../../includes/functions_user.php';
-
 class admin_input_test extends \phpbb_database_test_case
 {
 	/** @var bool A return value for check_form_key() */
@@ -23,7 +21,7 @@ class admin_input_test extends \phpbb_database_test_case
 	/** @var \phpbb\user_loader */
 	protected $user_loader;
 
-	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\language\language */
+	/** @var \phpbb\language\language */
 	protected $language;
 
 	/** @var \PHPUnit_Framework_MockObject_MockObject|\phpbb\request\request */
@@ -99,26 +97,26 @@ class admin_input_test extends \phpbb_database_test_case
 	public function get_form_data_data()
 	{
 		return array(
-			array(false, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', '', 0, array('The submitted form was invalid. Try submitting again.')),
-			array(true, '', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', '', 0, array('AD_NAME_REQUIRED')),
-			array(true, str_repeat('a', 256), 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', '', 0, array('AD_NAME_TOO_LONG')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', 'blah', '5', '', '', '', 0, array('AD_END_DATE_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '1970-01-01', '5', '', '', '', 0, array('AD_END_DATE_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '0', '', '', '', 0, array('AD_PRIORITY_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '11', '', '', '', 0, array('AD_PRIORITY_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '-1', '', '', 0, array('AD_VIEWS_LIMIT_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '-1', '', 0, array('AD_CLICKS_LIMIT_INVALID')),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', 'adm', 0, array('AD_OWNER_INVALID')),
-			array(false, '', 'Ad Note #1', 'Ad Code #1', '', '', 'blah', '0', '-1', '-1', 'adm', 0, array(
-				'The submitted form was invalid. Try submitting again.',
+			array(false, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['FORM_INVALID']),
+			array(true, ['', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['AD_NAME_REQUIRED']),
+			array(true, [str_repeat('a', 256), 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', ''], 0, ['AD_NAME_TOO_LONG']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', 'blah', '5', '', '', ''], 0, ['AD_END_DATE_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '1970-01-01', '5', '', '', ''], 0, ['AD_END_DATE_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '0', '', '', ''], 0, ['AD_PRIORITY_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '11', '', '', ''], 0, ['AD_PRIORITY_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '-1', '', ''], 0, ['AD_VIEWS_LIMIT_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '-1', ''], 0, ['AD_CLICKS_LIMIT_INVALID']),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '', '', '', '5', '', '', 'adm'], 0, ['AD_OWNER_INVALID']),
+			array(false, ['', 'Ad Note #1', 'Ad Code #1', '', '', 'blah', '0', '-1', '-1', 'adm'], 0, [
+				'FORM_INVALID',
 				'AD_NAME_REQUIRED',
 				'AD_END_DATE_INVALID',
 				'AD_PRIORITY_INVALID',
 				'AD_VIEWS_LIMIT_INVALID',
 				'AD_CLICKS_LIMIT_INVALID',
 				'AD_OWNER_INVALID',
-			)),
-			array(true, 'Ad Name #1', 'Ad Note #1', 'Ad Code #1', '1', array('above_header', 'above_footer'), '2033-01-01', '4', '50', '30', 'admin', '2', array()),
+			]),
+			array(true, ['Ad Name #1', 'Ad Note #1', 'Ad Code #1', '1', array('above_header', 'above_footer'), '2033-01-01', '4', '50', '30', 'admin'], 2, []),
 		);
 	}
 
@@ -127,8 +125,10 @@ class admin_input_test extends \phpbb_database_test_case
 	 *
 	 * @dataProvider get_form_data_data
 	 */
-	public function test_get_form_data($valid_form, $ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_end_date, $ad_priority, $ad_views_limit, $ad_clicks_limit, $ad_owner, $ad_owner_expected, $errors)
+	public function test_get_form_data($valid_form, $data, $ad_owner_expected, $errors)
 	{
+		list($ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_end_date, $ad_priority, $ad_views_limit, $ad_clicks_limit, $ad_owner) = $data;
+
 		self::$valid_form = $valid_form;
 		$input_controller = $this->get_input_controller();
 
@@ -136,7 +136,7 @@ class admin_input_test extends \phpbb_database_test_case
 			->method('variable')
 			->will($this->onConsecutiveCalls($ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_end_date, $ad_priority, $ad_views_limit, $ad_clicks_limit, $ad_owner));
 
-		$result = $input_controller->get_form_data('random string');
+		$result = $input_controller->get_form_data();
 
 		if (!empty($errors))
 		{

--- a/tests/event/clicks_test.php
+++ b/tests/event/clicks_test.php
@@ -26,7 +26,7 @@ class clicks_test extends main_listener_base
 	}
 
 	/**
-	 * Test the adblocker event
+	 * Test the clicks event
 	 *
 	 * @dataProvider data_clicks
 	 */

--- a/tests/event/views_test.php
+++ b/tests/event/views_test.php
@@ -67,8 +67,8 @@ class views_test extends main_listener_base
 			$this->template->expects($this->at(1))
 				->method('assign_vars')
 				->with(array(
-					'S_INCREMENT_VIEWS'		=> true,
-					'U_PHPBB_ADS_VIEWS'	=> "app.php/adsview/1",
+					'S_INCREMENT_VIEWS'	=> true,
+					'U_PHPBB_ADS_VIEWS'	=> 'app.php/adsview/1',
 				));
 		}
 

--- a/tests/fixtures/ad.xml
+++ b/tests/fixtures/ad.xml
@@ -139,6 +139,13 @@
 		<column>user_permissions</column>
 		<column>user_sig</column>
 		<row>
+			<value>1</value>
+			<value>Anonymous</value>
+			<value>Anonymous</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
 			<value>2</value>
 			<value>admin</value>
 			<value>admin</value>


### PR DESCRIPTION
Closes #87 
Fixes #85 
@senky 

mainly because @paul999 threw up when he saw `user_get_id_name` and I don't really like that function either.

This change also led me to refactor the validators, they now return the value being validated. This is done, in general, so that the date and ad owner validators can return the properly modified new values themselves (so ad owner is converted from username to id if valid, and date is converted to timestamp if valid).

One UX change resulting from this, if an ad owner was deleted, when you edit their ad, you will now see "Anonymous" listed under ad owner, which makes some sense since the ad is still assigned to a user that is gone. But you can't save it with Anonymous, attempting to will notify you to fix the ad owner.

Updating the validators also led me to add a validator for the Ad Code, to test for emoji characters which cause a fatal SQL error.

Also this PR includes some fixes to tests that were discovered.