### PR TITLE
Basic orphaned banner handling

### DIFF
--- a/ad/manager.php
+++ b/ad/manager.php
@@ -150,6 +150,22 @@ class manager
 	}
 
 	/**
+	 * Get code from every advertisement.
+	 *
+	 * @return array List of advertisement code
+	 */
+	public function get_all_ad_codes()
+	{
+		$sql = 'SELECT ad_code
+			FROM ' . $this->ads_table;
+		$result = $this->db->sql_query($sql);
+		$data = array_column($this->db->sql_fetchrowset($result), 'ad_code');
+		$this->db->sql_freeresult($result);
+
+		return $data;
+	}
+
+	/**
 	 * Get all owner's ads
 	 *
 	 * @param    int $user_id Ad owner

--- a/adm/style/event/acp_overall_footer_after.html
+++ b/adm/style/event/acp_overall_footer_after.html
@@ -183,13 +183,11 @@
 							$('#ad_code').val(function(i, text) {
 								return (text.length ? text + "\n\n" : '') + data.text;
 							});
-							{% if S_ADD_AD %}
 							$('<input>', {
 								type: 'hidden',
 								name: 'uploaded_banners[]',
 								value: data.filename
 							}).appendTo($form);
-							{% endif %}
 						}
 						else {
 							phpbb.alert(data.title, data.text);

--- a/adm/style/event/acp_overall_footer_after.html
+++ b/adm/style/event/acp_overall_footer_after.html
@@ -183,6 +183,13 @@
 							$('#ad_code').val(function(i, text) {
 								return (text.length ? text + "\n\n" : '') + data.text;
 							});
+							{% if S_ADD_AD %}
+							$('<input>', {
+								type: 'hidden',
+								name: 'uploaded_banners[]',
+								value: data.filename
+							}).appendTo($form);
+							{% endif %}
 						}
 						else {
 							phpbb.alert(data.title, data.text);

--- a/adm/style/manage_ads.html
+++ b/adm/style/manage_ads.html
@@ -34,6 +34,11 @@
 	</form>
 
 	<form id="acp_admanagement_add" method="post" action="{{ U_ACTION }}" enctype="multipart/form-data">
+		{% if S_ADD_AD %}
+			{% for uploaded_banner in loops.uploaded_banners %}
+				<input type="hidden" name="uploaded_banners[]" value="{{ uploaded_banner.FILENAME }}">
+			{% endfor %}
+		{% endif %}
 		<fieldset>
 			<legend>{{ lang('AD_DETAILS') }}</legend>
 			<dl>

--- a/adm/style/manage_ads.html
+++ b/adm/style/manage_ads.html
@@ -34,11 +34,9 @@
 	</form>
 
 	<form id="acp_admanagement_add" method="post" action="{{ U_ACTION }}" enctype="multipart/form-data">
-		{% if S_ADD_AD %}
-			{% for uploaded_banner in loops.uploaded_banners %}
-				<input type="hidden" name="uploaded_banners[]" value="{{ uploaded_banner.FILENAME }}">
-			{% endfor %}
-		{% endif %}
+		{% for uploaded_banner in loops.uploaded_banners %}
+			<input type="hidden" name="uploaded_banners[]" value="{{ uploaded_banner.FILENAME }}">
+		{% endfor %}
 		<fieldset>
 			<legend>{{ lang('AD_DETAILS') }}</legend>
 			<dl>

--- a/banner/banner.php
+++ b/banner/banner.php
@@ -134,16 +134,18 @@ class banner
 		$referenced = array();
 		foreach ((array) $ad_codes as $ad_code)
 		{
-			$referenced = array_merge($referenced, $this->extract_filenames($ad_code));
+			foreach ($this->extract_filenames($ad_code) as $filename)
+			{
+				$referenced[$filename] = true;
+			}
 		}
-		$referenced = array_flip(array_unique($referenced));
 
 		$removed = array();
 		foreach (array_unique((array) $candidates) as $filename)
 		{
 			if (!is_string($filename)
-				|| !preg_match(self::MANAGED_FILENAME_PATTERN, $filename)
-				|| isset($referenced[$filename]))
+				|| isset($referenced[$filename])
+				|| !preg_match(self::MANAGED_FILENAME_PATTERN, $filename))
 			{
 				continue;
 			}

--- a/banner/banner.php
+++ b/banner/banner.php
@@ -12,6 +12,9 @@ namespace phpbb\ads\banner;
 
 class banner
 {
+	/** @var string Pattern used by phpBB's unique_ext filename mode */
+	public const MANAGED_FILENAME_PATTERN = '/^[a-f0-9]{32}\.(?:gif|jpe?g|png)$/i';
+
 	/** @var \phpbb\files\upload */
 	protected $files_upload;
 
@@ -91,6 +94,77 @@ class banner
 	 */
 	public function remove()
 	{
-		$this->file->remove();
+		if ($this->file)
+		{
+			$this->file->remove();
+		}
+	}
+
+	/**
+	 * Extract Ads-managed banner filenames referenced by ad code.
+	 *
+	 * @param string $ad_code Advertisement code
+	 * @return array Unique banner filenames
+	 */
+	public function extract_filenames($ad_code)
+	{
+		$ad_code = html_entity_decode($ad_code, ENT_QUOTES, 'UTF-8');
+		preg_match_all(
+			'~(?:^|/)images/phpbb_ads/([a-f0-9]{32}\.(?:gif|jpe?g|png))(?![a-z0-9._-])~i',
+			$ad_code,
+			$matches
+		);
+
+		return array_values(array_unique($matches[1]));
+	}
+
+	/**
+	 * Remove candidate banners not referenced by supplied ad code.
+	 *
+	 * Only filenames produced by unique_ext are accepted. Failed removals are
+	 * left in place so banner cleanup cannot prevent an ad from being saved or
+	 * deleted.
+	 *
+	 * @param array $candidates Banner filenames eligible for removal
+	 * @param array $ad_codes Advertisement code that may still reference them
+	 * @return array Successfully removed filenames
+	 */
+	public function remove_unreferenced($candidates, $ad_codes)
+	{
+		$referenced = array();
+		foreach ((array) $ad_codes as $ad_code)
+		{
+			$referenced = array_merge($referenced, $this->extract_filenames($ad_code));
+		}
+		$referenced = array_flip(array_unique($referenced));
+
+		$removed = array();
+		foreach (array_unique((array) $candidates) as $filename)
+		{
+			if (!is_string($filename)
+				|| !preg_match(self::MANAGED_FILENAME_PATTERN, $filename)
+				|| isset($referenced[$filename]))
+			{
+				continue;
+			}
+
+			$path = $this->root_path . 'images/phpbb_ads/' . $filename;
+			if (!is_file($path))
+			{
+				continue;
+			}
+
+			try
+			{
+				$this->filesystem->remove($path);
+				$removed[] = $filename;
+			}
+			catch (\phpbb\filesystem\exception\filesystem_exception $e)
+			{
+				// Leave file in place. Ad lifecycle operation must still succeed.
+			}
+		}
+
+		return $removed;
 	}
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -69,6 +69,7 @@ services:
             - '@language'
             - '@request'
             - '@phpbb.ads.ad.manager'
+            - '@phpbb.ads.banner.banner'
             - '@config'
             - '@phpbb.ads.admin.input'
             - '@phpbb.ads.helper'

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -553,6 +553,10 @@ class admin_controller
 				// Only insert new ad locations to DB when ad exists
 				$this->manager->delete_ad_locations($ad_id);
 				$this->manager->insert_ad_locations($ad_id, $this->data['ad_locations']);
+				if (!empty($this->data['uploaded_banners']))
+				{
+					$this->banner->remove_unreferenced($this->data['uploaded_banners'], array($this->data['ad_code']));
+				}
 
 				$this->helper->log('EDIT', $this->data['ad_name']);
 

--- a/controller/admin_controller.php
+++ b/controller/admin_controller.php
@@ -35,6 +35,9 @@ class admin_controller
 	/** @var \phpbb\ads\ad\manager */
 	protected $manager;
 
+	/** @var \phpbb\ads\banner\banner */
+	protected $banner;
+
 	/** @var \phpbb\config\config */
 	protected $config;
 
@@ -66,6 +69,7 @@ class admin_controller
 	 * @param \phpbb\language\language          $language          Language object
 	 * @param \phpbb\request\request            $request           Request object
 	 * @param \phpbb\ads\ad\manager             $manager           Advertisement manager object
+	 * @param \phpbb\ads\banner\banner          $banner            Banner manager object
 	 * @param \phpbb\config\config              $config            Config object
 	 * @param \phpbb\ads\controller\admin_input $input             Admin input object
 	 * @param \phpbb\ads\controller\helper      $helper            Helper object
@@ -75,12 +79,13 @@ class admin_controller
 	 * @param string                            $root_path         phpBB root path
 	 * @param string                            $php_ext           PHP extension
 	 */
-	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, \phpbb\request\request $request, \phpbb\ads\ad\manager $manager, \phpbb\config\config $config, \phpbb\ads\controller\admin_input $input, \phpbb\ads\controller\helper $helper, \phpbb\ads\analyser\manager $analyser, \phpbb\extension\manager $extension_manager, \phpbb\controller\helper $controller_helper, $root_path, $php_ext)
+	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, \phpbb\request\request $request, \phpbb\ads\ad\manager $manager, \phpbb\ads\banner\banner $banner, \phpbb\config\config $config, \phpbb\ads\controller\admin_input $input, \phpbb\ads\controller\helper $helper, \phpbb\ads\analyser\manager $analyser, \phpbb\extension\manager $extension_manager, \phpbb\controller\helper $controller_helper, $root_path, $php_ext)
 	{
 		$this->template = $template;
 		$this->language = $language;
 		$this->request = $request;
 		$this->manager = $manager;
+		$this->banner = $banner;
 		$this->config = $config;
 		$this->input = $input;
 		$this->helper = $helper;
@@ -283,6 +288,7 @@ class admin_controller
 				{
 					$this->error('ACP_AD_DOES_NOT_EXIST');
 				}
+				$banner_filenames = $this->banner->extract_filenames($ad_data['ad_code'] ?? '');
 
 				// Delete the ad before removing its related data
 				$success = $this->manager->delete_ad($ad_id);
@@ -293,6 +299,10 @@ class admin_controller
 
 				$this->manager->delete_ad_locations($ad_id);
 				$this->manager->delete_ad_groups($ad_id);
+				if (!empty($banner_filenames))
+				{
+					$this->banner->remove_unreferenced($banner_filenames, $this->manager->get_all_ad_codes());
+				}
 				$this->toggle_permission($ad_data['ad_owner']);
 				$this->helper->log('DELETE', $ad_data['ad_name']);
 
@@ -462,7 +472,8 @@ class admin_controller
 			$this->error('FORM_INVALID');
 		}
 
-		$this->data['ad_code'] = $this->input->banner_upload($this->data['ad_code']);
+		$this->data['uploaded_banners'] = $this->data['uploaded_banners'] ?? array();
+		$this->data['ad_code'] = $this->input->banner_upload($this->data['ad_code'], $this->data['uploaded_banners']);
 	}
 
 	/**
@@ -509,6 +520,10 @@ class admin_controller
 			$ad_id = $this->manager->insert_ad($this->data);
 			$this->toggle_permission($this->data['ad_owner']);
 			$this->manager->insert_ad_locations($ad_id, $this->data['ad_locations']);
+			if (!empty($this->data['uploaded_banners']))
+			{
+				$this->banner->remove_unreferenced($this->data['uploaded_banners'], array($this->data['ad_code']));
+			}
 
 			$this->helper->log('ADD', $this->data['ad_name']);
 

--- a/controller/admin_input.php
+++ b/controller/admin_input.php
@@ -108,6 +108,7 @@ class admin_input
 			'ad_consent'		=> $this->request->variable('ad_consent', 1),
 			'ad_views_enabled'	=> $this->request->variable('ad_views_enabled', 0),
 			'ad_clicks_enabled'	=> $this->request->variable('ad_clicks_enabled', 0),
+			'uploaded_banners'	=> $this->request->variable('uploaded_banners', array('')),
 		);
 
 		// Validate form key
@@ -138,10 +139,11 @@ class admin_input
 	/**
 	 * Upload image and return updated ad code or <img> of new banner when using ajax.
 	 *
-	 * @param	 string	 $ad_code	 Current ad code
+	 * @param string $ad_code Current ad code
+	 * @param array|null $uploaded_banners Banners uploaded while creating this ad
 	 * @return	 string	 \phpbb\json_response when request is ajax or updated ad code otherwise.
 	 */
-	public function banner_upload($ad_code)
+	public function banner_upload($ad_code, &$uploaded_banners = null)
 	{
 		try
 		{
@@ -149,10 +151,15 @@ class admin_input
 			$realname = $this->banner->upload();
 
 			$banner_html = '<img src="' . generate_board_url() . '/images/phpbb_ads/' . $realname . '" />';
+			if (is_array($uploaded_banners))
+			{
+				$uploaded_banners[] = $realname;
+				$uploaded_banners = array_values(array_unique($uploaded_banners));
+			}
 
 			if ($this->request->is_ajax())
 			{
-				$this->send_ajax_response(true, $banner_html);
+				$this->send_ajax_response(true, $banner_html, array('filename' => $realname));
 			}
 
 			$ad_code = ($ad_code ? $ad_code . "\n\n" : '') . $banner_html;
@@ -316,15 +323,16 @@ class admin_input
 	 *
 	 * @param bool $success Is request successful?
 	 * @param string $text Text to return
+	 * @param array $extra Additional response data
 	 */
-	public function send_ajax_response($success, $text)
+	public function send_ajax_response($success, $text, $extra = array())
 	{
 		$json_response = new \phpbb\json_response;
-		$json_response->send(array(
+		$json_response->send(array_merge($extra, array(
 			'success'	=> $success,
 			'title'		=> $this->language->lang('INFORMATION'),
 			'text'		=> $text,
-		));
+		)));
 	}
 
 	/**

--- a/controller/helper.php
+++ b/controller/helper.php
@@ -85,6 +85,12 @@ class helper
 	{
 		$this->assign_locations($data['ad_locations']);
 		$this->assign_groups(($data['ad_id'] ?? 0), ($data['ad_groups'] ?? array()));
+		foreach (array_unique($data['uploaded_banners'] ?? array()) as $filename)
+		{
+			$this->template->assign_block_vars('uploaded_banners', array(
+				'FILENAME' => $filename,
+			));
+		}
 
 		$errors = array_map(array($this->language, 'lang'), $errors);
 		$this->template->assign_vars(array(

--- a/tests/ad/get_all_ads_test.php
+++ b/tests/ad/get_all_ads_test.php
@@ -23,4 +23,13 @@ class get_all_ads_test extends ad_base
 		$ad_ids = array_column($ads, 'ad_id');
 		self::assertEquals(array(1,2,3,4,5,6,7), $ad_ids);
 	}
+
+	public function test_get_all_ad_codes()
+	{
+		$codes = $this->get_manager()->get_all_ad_codes();
+
+		self::assertCount(7, $codes);
+		self::assertContains('Ad Code #1', $codes);
+		self::assertContains('Ad Code #7', $codes);
+	}
 }

--- a/tests/banner/cleanup_test.php
+++ b/tests/banner/cleanup_test.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ *
+ * Advertisement management. An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2026 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\ads\tests\banner;
+
+class cleanup_test extends banner_base
+{
+	/** @var string */
+	protected $cleanup_root;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->cleanup_root = sys_get_temp_dir() . '/phpbb_ads_cleanup_' . md5(uniqid('', true)) . '/';
+		mkdir($this->cleanup_root . 'images/phpbb_ads', 0777, true);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function tearDown(): void
+	{
+		foreach (glob($this->cleanup_root . 'images/phpbb_ads/*') as $file)
+		{
+			unlink($file);
+		}
+		rmdir($this->cleanup_root . 'images/phpbb_ads');
+		rmdir($this->cleanup_root . 'images');
+		rmdir($this->cleanup_root);
+
+		parent::tearDown();
+	}
+
+	public function test_extract_filenames()
+	{
+		$first = str_repeat('a', 32) . '.jpg';
+		$second = str_repeat('b', 32) . '.png';
+		$code = '<img src="https://example.com/forum/images/phpbb_ads/' . $first . '">'
+			. '<img src=&quot;/images/phpbb_ads/' . $second . '?v=1&quot;>'
+			. '<img src="/images/phpbb_ads/not-managed.jpg">'
+			. '<img src="/other/' . str_repeat('c', 32) . '.gif">'
+			. '<img src="/images/phpbb_ads/' . $first . '">';
+
+		$manager = new \phpbb\ads\banner\banner($this->files_upload, $this->filesystem, $this->cleanup_root);
+
+		self::assertSame(array($first, $second), $manager->extract_filenames($code));
+	}
+
+	public function test_remove_only_unreferenced_managed_files()
+	{
+		$referenced = str_repeat('a', 32) . '.jpg';
+		$orphan = str_repeat('b', 32) . '.png';
+		$untracked = str_repeat('d', 32) . '.gif';
+		file_put_contents($this->cleanup_root . 'images/phpbb_ads/' . $referenced, 'referenced');
+		file_put_contents($this->cleanup_root . 'images/phpbb_ads/' . $orphan, 'orphan');
+		file_put_contents($this->cleanup_root . 'images/phpbb_ads/' . $untracked, 'untracked');
+
+		$this->filesystem->expects(self::once())
+			->method('remove')
+			->with($this->cleanup_root . 'images/phpbb_ads/' . $orphan);
+
+		$manager = new \phpbb\ads\banner\banner($this->files_upload, $this->filesystem, $this->cleanup_root);
+		$removed = $manager->remove_unreferenced(
+			array($referenced, $orphan, '../../config.php', str_repeat('c', 32) . '.gif'),
+			array('<img src="/images/phpbb_ads/' . $referenced . '">')
+		);
+
+		self::assertSame(array($orphan), $removed);
+	}
+}

--- a/tests/banner/cleanup_test.php
+++ b/tests/banner/cleanup_test.php
@@ -78,4 +78,21 @@ class cleanup_test extends banner_base
 
 		self::assertSame(array($orphan), $removed);
 	}
+
+	public function test_failed_removal_is_left_in_place()
+	{
+		$orphan = str_repeat('a', 32) . '.jpg';
+		$path = $this->cleanup_root . 'images/phpbb_ads/' . $orphan;
+		file_put_contents($path, 'orphan');
+
+		$this->filesystem->expects(self::once())
+			->method('remove')
+			->with($path)
+			->willThrowException(new \phpbb\filesystem\exception\filesystem_exception('FILESYSTEM_CANNOT_DELETE_FILES', $path));
+
+		$manager = new \phpbb\ads\banner\banner($this->files_upload, $this->filesystem, $this->cleanup_root);
+
+		self::assertSame(array(), $manager->remove_unreferenced(array($orphan), array()));
+		self::assertFileExists($path);
+	}
 }

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -32,6 +32,9 @@ class admin_controller_test extends \phpbb_database_test_case
 	/** @var \PHPUnit\Framework\MockObject\MockObject|\phpbb\ads\ad\manager */
 	protected $manager;
 
+	/** @var \PHPUnit\Framework\MockObject\MockObject|\phpbb\ads\banner\banner */
+	protected $banner;
+
 	/** @var \PHPUnit\Framework\MockObject\MockObject|\phpbb\config\config */
 	protected $config;
 
@@ -100,6 +103,9 @@ class admin_controller_test extends \phpbb_database_test_case
 		$this->manager = $this->getMockBuilder('\phpbb\ads\ad\manager')
 			->disableOriginalConstructor()
 			->getMock();
+		$this->banner = $this->getMockBuilder('\phpbb\ads\banner\banner')
+			->disableOriginalConstructor()
+			->getMock();
 		$this->config = $this->getMockBuilder('\phpbb\config\config')
 			->disableOriginalConstructor()
 			->getMock();
@@ -145,6 +151,7 @@ class admin_controller_test extends \phpbb_database_test_case
 			$this->language,
 			$this->request,
 			$this->manager,
+			$this->banner,
 			$this->config,
 			$this->input,
 			$this->helper,
@@ -318,6 +325,7 @@ class admin_controller_test extends \phpbb_database_test_case
 				$this->language,
 				$this->request,
 				$this->manager,
+				$this->banner,
 				$this->config,
 				$this->input,
 				$this->helper,
@@ -409,6 +417,7 @@ class admin_controller_test extends \phpbb_database_test_case
 		$data = array(
 			'ad_code'		=> '<!-- AD CODE SAMPLE -->',
 			'ad_locations'	=> array(),
+			'uploaded_banners' => array(),
 		);
 
 		$this->input->expects(self::once())
@@ -457,6 +466,7 @@ class admin_controller_test extends \phpbb_database_test_case
 		$data = array(
 			'ad_code'		=> '<!-- AD CODE SAMPLE -->',
 			'ad_locations'	=> array(),
+			'uploaded_banners' => array(),
 		);
 
 		$banner_ad_code = '<!-- BANNER AD CODE -->';
@@ -467,7 +477,7 @@ class admin_controller_test extends \phpbb_database_test_case
 
 		$this->input->expects(self::once())
 			->method('banner_upload')
-			->with($data['ad_code'])
+			->with($data['ad_code'], $data['uploaded_banners'])
 			->willReturn($banner_ad_code);
 
 		$data['ad_code'] = $banner_ad_code;
@@ -631,6 +641,7 @@ class admin_controller_test extends \phpbb_database_test_case
 			'ad_code'		=> 'Ad Code #1',
 			'ad_locations'	=> array(),
 			'ad_owner'		=> $ad_owner,
+			'uploaded_banners' => array(str_repeat('a', 32) . '.jpg'),
 		);
 
 		$this->input->expects(self::once())
@@ -666,6 +677,10 @@ class admin_controller_test extends \phpbb_database_test_case
 			$this->manager->expects(self::once())
 				->method('insert_ad_locations')
 				->with(1, array());
+
+			$this->banner->expects(self::once())
+				->method('remove_unreferenced')
+				->with($data['uploaded_banners'], array($data['ad_code']));
 
 			$this->helper->expects(self::once())
 				->method('log')
@@ -1191,10 +1206,16 @@ class admin_controller_test extends \phpbb_database_test_case
 		}
 		else
 		{
+			$filename = str_repeat('a', 32) . '.jpg';
+			$ad_code = '<img src="/images/phpbb_ads/' . $filename . '">';
 			$this->manager->expects(self::once())
 				->method('get_ad')
 				->with($ad_id)
-				->willReturn(array('id' => $ad_id, 'ad_owner' => $ad_owner, 'ad_name' => ''));
+				->willReturn(array('id' => $ad_id, 'ad_owner' => $ad_owner, 'ad_name' => '', 'ad_code' => $ad_code));
+			$this->banner->expects(self::once())
+				->method('extract_filenames')
+				->with($ad_code)
+				->willReturn(array($filename));
 			$this->manager->expects(self::once())
 				->method('delete_ad_locations')
 				->with($ad_id);
@@ -1205,6 +1226,12 @@ class admin_controller_test extends \phpbb_database_test_case
 				->method('delete_ad')
 				->with($ad_id)
 				->willReturn((bool) $ad_id);
+			$this->manager->expects(self::once())
+				->method('get_all_ad_codes')
+				->willReturn(array('another ad'));
+			$this->banner->expects(self::once())
+				->method('remove_unreferenced')
+				->with(array($filename), array('another ad'));
 			$this->manager->expects(($ad_owner ? self::once() : self::never()))
 				->method('get_ads_by_owner')
 				->with($ad_owner)

--- a/tests/controller/admin_controller_test.php
+++ b/tests/controller/admin_controller_test.php
@@ -956,6 +956,7 @@ class admin_controller_test extends \phpbb_database_test_case
 			'ad_code'		=> 'Ad Code #1',
 			'ad_locations'	=> array(),
 			'ad_owner'		=> $ad_owner,
+			'uploaded_banners' => array(str_repeat('b', 32) . '.png'),
 		);
 
 		$this->manager->expects(self::once())
@@ -1020,6 +1021,10 @@ class admin_controller_test extends \phpbb_database_test_case
 				$this->manager->expects(self::once())
 					->method('insert_ad_locations')
 					->with(1, array());
+
+				$this->banner->expects(self::once())
+					->method('remove_unreferenced')
+					->with($data['uploaded_banners'], array($data['ad_code']));
 
 				$this->helper->expects(self::once())
 					->method('log')

--- a/tests/controller/admin_input_test.php
+++ b/tests/controller/admin_input_test.php
@@ -148,13 +148,14 @@ class admin_input_test extends \phpbb_database_test_case
 		[$ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_start_date, $ad_end_date, $ad_priority, $ad_content_only, $ad_views_limit, $ad_clicks_limit, $ad_owner, $ad_groups, $ad_centering, $ad_consent] = $data;
 		$ad_views_enabled = isset($data[15]) ? $data[15] : 0;
 		$ad_clicks_enabled = isset($data[16]) ? $data[16] : 0;
+		$uploaded_banners = isset($data[17]) ? $data[17] : array();
 
 		self::$valid_form = $valid_form;
 		$input_controller = $this->get_input_controller();
 
-		$this->request->expects(self::exactly(17))
+		$this->request->expects(self::exactly(18))
 			->method('variable')
-			->will(self::onConsecutiveCalls($ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_start_date, $ad_end_date, $ad_priority, $ad_content_only, $ad_views_limit, $ad_clicks_limit, $ad_owner, $ad_groups, $ad_centering, $ad_consent, $ad_views_enabled, $ad_clicks_enabled));
+			->will(self::onConsecutiveCalls($ad_name, $ad_note, $ad_code, $ad_enabled, $ad_locations, $ad_start_date, $ad_end_date, $ad_priority, $ad_content_only, $ad_views_limit, $ad_clicks_limit, $ad_owner, $ad_groups, $ad_centering, $ad_consent, $ad_views_enabled, $ad_clicks_enabled, $uploaded_banners));
 
 		$result = $input_controller->get_form_data($existing_start_date, $existing_end_date);
 
@@ -183,6 +184,7 @@ class admin_input_test extends \phpbb_database_test_case
 				'ad_consent'	  => $ad_consent,
 				'ad_views_enabled' => $ad_views_enabled,
 				'ad_clicks_enabled' => $ad_clicks_enabled,
+				'uploaded_banners' => $uploaded_banners,
 			), $result);
 		}
 	}
@@ -250,8 +252,10 @@ class admin_input_test extends \phpbb_database_test_case
 			$this->setExpectedTriggerError(E_WARNING);
 		}
 
-		$result = $input_controller->banner_upload($ad_code);
+		$uploaded_banners = array();
+		$result = $input_controller->banner_upload($ad_code, $uploaded_banners);
 		self::assertEquals($ad_code_expected, $result);
+		self::assertSame($can_create_directory && $can_move_file ? array('abcdef.jpg') : array(), $uploaded_banners);
 
 		if (count($file_error))
 		{

--- a/tests/controller/helper_test.php
+++ b/tests/controller/helper_test.php
@@ -154,6 +154,7 @@ class helper_test extends \phpbb_database_test_case
 					  'ad_centering'	=> false,
 					  'ad_consent'		=> 1,
 					  'ad_locations'	=> [],
+					  'uploaded_banners' => [str_repeat('a', 32) . '.jpg'],
 				  ), '', array('AD_PRIORITY_INVALID'), true, 'AD_PRIORITY_INVALID'),
 			array(array(
 					  'ad_name'			=> 'Ad Name #1',
@@ -238,6 +239,13 @@ class helper_test extends \phpbb_database_test_case
 		$this->manager->expects(self::once())
 			->method('load_groups')
 			->willReturn(array());
+
+		$uploaded_banners = $data['uploaded_banners'] ?? array();
+		$this->template->expects(empty($uploaded_banners) ? self::never() : self::once())
+			->method('assign_block_vars')
+			->with('uploaded_banners', array(
+				'FILENAME' => $uploaded_banners[0] ?? '',
+			));
 
 		$this->template->expects(self::once())
 			->method('assign_vars')


### PR DESCRIPTION
This will remove orphaned banners now during ad creation, ad editing, and ad deletion. A cron-based orphaned banner could be added later, but for now I think this is good enough.